### PR TITLE
doc: add note

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 A session plugin for [fastify](http://fastify.io/). 
 Requires the [fastify-cookie](https://github.com/fastify/fastify-cookie) plugin.
 
-**NOTE:** This is the continuation of [fastify-session](https://github.com/SerayaEryn/fastify-session) which is unmaintained by now.
+**NOTE:** This is the continuation of [fastify-session](https://github.com/SerayaEryn/fastify-session) which is unmaintained by now. All work credit till [`e201f7`](https://github.com/fastify/session/commit/e201f78fc9d7bd33c6f2e84988be7c8af4b5a8a3) commit goes to [SerayaEryn](https://github.com/SerayaEryn) and contributors.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 A session plugin for [fastify](http://fastify.io/). 
 Requires the [fastify-cookie](https://github.com/fastify/fastify-cookie) plugin.
 
+**NOTE:** This is the continuation of [fastify-session](https://github.com/SerayaEryn/fastify-session) which is unmaintained by now.
+
 ## Install
 
 ```


### PR DESCRIPTION
Added note to explain the reason of the move of the repo.

If there is no other addition i think we can make this repo public + publishing on npm. Just need to ensure we want to use namespace which will break the `fastify-*` naming convention.