### PR TITLE
doc: fix npm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Build Status](https://github.com/fastify/session/workflows/ci/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/fastify/session/badge.svg?branch=master)](https://coveralls.io/github/fastify/session?branch=master)
-[![NPM version](https://img.shields.io/npm/v/fastify-session.svg?style=flat)](https://www.npmjs.com/package/fastify-session)
+[![NPM version](https://img.shields.io/npm/v/@fastify/session.svg?style=flat)](https://www.npmjs.com/package/@fastify/session)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)
 
 A session plugin for [fastify](http://fastify.io/). 


### PR DESCRIPTION
npm badge was still refering to old repository.