### PR TITLE
fix: incorrect title for session cookie test

### DIFF
--- a/test/base.test.js
+++ b/test/base.test.js
@@ -4,16 +4,18 @@ const test = require('ava')
 const fastifyPlugin = require('fastify-plugin')
 const { testServer, request, DEFAULT_OPTIONS, DEFAULT_COOKIE } = require('./util')
 
-test('should set session cookie on post without params', async (t) => {
-  t.plan(1)
+test('should not set session cookie on post without params', async (t) => {
+  t.plan(3)
   const port = await testServer((request, reply) => reply.send(200), DEFAULT_OPTIONS)
 
-  const { statusCode } = await request({
+  const { statusCode, body, cookie } = await request({
     method: 'POST',
     url: `http://localhost:${port}/test`,
     headers: { 'content-type': 'application/json' }
   })
   t.is(statusCode, 400)
+  t.true(body.includes('FST_ERR_CTP_EMPTY_JSON_BODY'))
+  t.falsy(cookie)
 })
 
 test('should set session cookie', async (t) => {


### PR DESCRIPTION
Resolves #37: This PR changes the test title of "should set session cookie on post without params" to "should not set session cookie on post without params", and adds assertions that the session cookie is not set.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
