### PR TITLE
Add Get/Set methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ Updates the `expires` property of the session.
 
 Regenerates the session by generating a new `sessionId`.
 
+#### Session#get(key)
+
+Gets a value from the session
+
+#### Session#set(key, value)
+
+Sets a value in the session
+
 ### fastify.decryptSession(sessionId, request, next)
 This plugin also decorates the fastify instance with `decryptSession` in case you want to decrypt the session manually. 
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -43,6 +43,14 @@ module.exports = class Session {
     }
   }
 
+  get (key) {
+    return this[key]
+  }
+
+  set (key, value) {
+    this[key] = value
+  }
+
   [sign] () {
     return cookieSignature.sign(this.sessionId, this[secretKey])
   }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -85,6 +85,19 @@ test('should add session.sessionId object to request', async (t) => {
   t.is(response.statusCode, 200)
 })
 
+test('should allow get/set methods for fetching/updating session values', async (t) => {
+  t.plan(2)
+  const port = await testServer((request, reply) => {
+    request.session.set('foo', 'bar')
+    t.is(request.session.get('foo'), 'bar')
+    reply.send(200)
+  }, DEFAULT_OPTIONS)
+
+  const { response } = await request(`http://localhost:${port}`)
+
+  t.is(response.statusCode, 200)
+})
+
 test('should use custom sessionId generator if available', async (t) => {
   t.plan(2)
   const port = await testServer((request, reply) => {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -19,6 +19,10 @@ declare module "fastify" {
     touch(): void;
     /** Regenerates the session by generating a new `sessionId`. */
     regenerate(): void;
+    /** sets values in the session. */
+    set(key: string, value: any): void;
+    /** gets values from the session. */
+    get(key: string): any;
   }
 }
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -20,9 +20,9 @@ declare module "fastify" {
     /** Regenerates the session by generating a new `sessionId`. */
     regenerate(): void;
     /** sets values in the session. */
-    set(key: string, value: any): void;
+    set(key: string, value: unknown): void;
     /** gets values from the session. */
-    get(key: string): any;
+    get<T>(key: string): T;
   }
 }
 

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -18,6 +18,8 @@ class EmptyStore {
 
 declare module "fastify" {
   interface Session {
+    get<T>(key: string): T;
+    set(key: string, value: unknown): void;
     user?: {
       id: number;
     };
@@ -69,5 +71,7 @@ app.route({
       expectType<Session | undefined>(session)
       expectType<{ id: number } | undefined>(session?.user)
     })
+    expectType<void>(request.session.set('foo', 'bar'))
+    expectType<string>(request.session.get('foo'))
   },
 });


### PR DESCRIPTION
This PR adds `get`, `set` methods for using the session. 
These methods are need for integration with `fastify-passport` (See https://github.com/fastify/fastify-passport/pull/421)