### PR TITLE
fix (types): fix callbacks types and ensure compatibility with `express-session` stores

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -1,39 +1,57 @@
-/// <reference types="node" />
+/// <reference types='node' />
 
-import { FastifyPluginCallback } from "fastify";
-import type * as Fastify from "fastify";
+import { FastifyPluginCallback } from 'fastify';
+import type * as Fastify from 'fastify';
 
-declare module "fastify" {
+declare module 'fastify' {
   interface FastifyRequest {
     /** Allows to access or modify the session data. */
     session: Fastify.Session;
+
     /** A session store. */
     sessionStore: Readonly<FastifySessionPlugin.SessionStore>;
+
     /** Allows to destroy the session in the store. */
-    destroySession(callback: (err?: Error) => void): void;
+    destroySession(callback: (err: Error) => void): void;
   }
-  interface Session {
-    sessionId: string;
-    encryptedSessionId: string;
-    /** Updates the `expires` property of the session. */
-    touch(): void;
-    /** Regenerates the session by generating a new `sessionId`. */
-    regenerate(): void;
-    /** sets values in the session. */
-    set(key: string, value: unknown): void;
-    /** gets values from the session. */
-    get<T>(key: string): T;
-  }
+
+  interface Session extends Partial<SessionData> {}
+}
+
+interface SessionData extends ExpressSessionData {
+  sessionId: string;
+
+  encryptedSessionId: string;
+
+  /** Updates the `expires` property of the session. */
+  touch(): void;
+
+  /** Regenerates the session by generating a new `sessionId`. */
+  regenerate(): void;
+
+  /** sets values in the session. */
+  set(key: string, value: unknown): void;
+
+  /** gets values from the session. */
+  get<T>(key: string): T;
+}
+
+interface ExpressSessionData {
+  cookie: FastifySessionPlugin.CookieOptions;
 }
 
 declare namespace FastifySessionPlugin {
   interface SessionStore {
-    set(sessionId: string, session: Fastify.Session, callback: (err?: Error) => void): void;
+    set(
+      sessionId: string,
+      session: Fastify.Session,
+      callback: (err: Error) => void
+    ): void;
     get(
       sessionId: string,
-      callback: (err?: Error, session?: Fastify.Session) => void
+      callback: (err: Error, session: Fastify.Session) => void
     ): void;
-    destroy(sessionId: string, callback: (err?: Error) => void): void;
+    destroy(sessionId: string, callback: (err: Error) => void): void;
   }
 
   interface Options {
@@ -52,10 +70,16 @@ declare namespace FastifySessionPlugin {
      * Secrets management is left up to the rest of the application.
      */
     secret: string | string[];
+
     /** The name of the session cookie. Defaults to `sessionId`. */
     cookieName?: string;
-    /** The options object used to generate the `Set-Cookie` header of the session cookie. */
+    /**
+     * The options object used to generate the `Set-Cookie` header of the session cookie.
+     *
+     * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
+     */
     cookie?: CookieOptions;
+
     /**
      * A session store.
      * Compatible to stores from express-session.
@@ -63,16 +87,19 @@ declare namespace FastifySessionPlugin {
      * Note: The default store should not be used in a production environment because it will leak memory.
      */
     store?: FastifySessionPlugin.SessionStore;
+
     /**
      * Save sessions to the store, even when they are new and not modified.
      * Defaults to true. Setting this to false can be useful to save storage space and to comply with the EU cookie law.
      */
     saveUninitialized?: boolean;
+
     /**
      * Force the session identifier cookie to be set on every response. The expiration is reset to the original maxAge, resetting the expiration countdown.
      * Defaults to true. This is typically used in conjuction with short, non-session-length maxAge values to provide a quick timeout of the session data with reduced potential of it occurring during on going server interactions.
      */
     rolling?: boolean;
+
     /** Function used to generate new session IDs. Defaults to uid(24). */
     idGenerator?: () => string;
   }
@@ -80,16 +107,22 @@ declare namespace FastifySessionPlugin {
   interface CookieOptions {
     /**  The `Path` attribute. Defaults to `/` (the root path).  */
     path?: string;
+
     /**  A `number` in milliseconds that specifies the `Expires` attribute by adding the specified milliseconds to the current date. If both `expires` and `maxAge` are set, then `expires` is used. */
     maxAge?: number;
+
     /**  The `boolean` value of the `HttpOnly` attribute. Defaults to true. */
     httpOnly?: boolean;
+
     /**  The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true. */
-    secure?: boolean | string;
+    secure?: boolean | 'auto';
+
     /**  The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used. */
-    expires?: Date | number;
-    /** The `boolean` or `string` of the `SameSite` attribute.  */
-    sameSite?: string | boolean;
+    expires?: Date;
+
+    /** A `boolean` or one of the `SameSite` string attributes. E.g.: `lax`, `node` or `strict`.  */
+    sameSite?: 'lax' | 'none' | 'strict' | boolean;
+
     /**  The `Domain` attribute. */
     domain?: string;
   }
@@ -97,13 +130,19 @@ declare namespace FastifySessionPlugin {
 
 export class MemoryStore implements FastifySessionPlugin.SessionStore {
   constructor(map?: Map<string, Fastify.Session>);
-  set(sessionId: string, session: Fastify.Session, callback: (err?: Error) => void): void;
-  get(sessionId: string, callback: (err?: Error, session?: Fastify.Session) => void): void;
-  destroy(sessionId: string, callback: (err?: Error) => void): void;
+  set(
+    sessionId: string,
+    session: Fastify.Session,
+    callback: (err: Error) => void
+  ): void;
+  get(
+    sessionId: string,
+    callback: (err: Error, session: Fastify.Session) => void
+  ): void;
+  destroy(sessionId: string, callback: (err: Error) => void): void;
 }
 
 export const Store: MemoryStore;
 
 declare const FastifySessionPlugin: FastifyPluginCallback<FastifySessionPlugin.Options>;
-
 export default FastifySessionPlugin;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -65,6 +65,7 @@ app.route({
     expectError((request.sessionStore = null));
     expectError(request.session.doesNotExist());
     expectType<{ id: number } | undefined>(request.session.user);
+    request.sessionStore.set('session-set-test', request.session, () => {})
     request.sessionStore.get('', (err, session) => {
       expectType<Error>(err);
       expectType<Session>(session);

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -1,12 +1,11 @@
-import { expectType, expectError } from "tsd";
-
-import session from "./types";
 import fastify, {
-  FastifyRequest,
   FastifyInstance,
   FastifyReply,
+  FastifyRequest,
   Session
-} from "fastify";
+} from 'fastify';
+import { expectError, expectType } from 'tsd';
+import plugin from '..';
 
 class EmptyStore {
   set(_sessionId: string, _session: any, _callback: Function) {}
@@ -16,7 +15,7 @@ class EmptyStore {
   destroy(_sessionId: string, _callback: Function) {}
 }
 
-declare module "fastify" {
+declare module 'fastify' {
   interface Session {
     get<T>(key: string): T;
     set(key: string, value: unknown): void;
@@ -27,51 +26,51 @@ declare module "fastify" {
 }
 
 const app: FastifyInstance = fastify();
-app.register(session);
-app.register(session, { secret: "DizIzSecret" });
-app.register(session, { secret: "DizIzSecret", rolling: true });
-app.register(session, {
-  secret: "ABCDEFGHIJKLNMOPQRSTUVWXYZ012345",
+app.register(plugin);
+app.register(plugin, { secret: 'DizIzSecret' });
+app.register(plugin, { secret: 'DizIzSecret', rolling: true });
+app.register(plugin, {
+  secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
   rolling: false,
   cookie: {
-    secure: false,
-  },
+    secure: false
+  }
 });
-app.register(session, {
-  secret: "ABCDEFGHIJKLNMOPQRSTUVWXYZ012345",
+app.register(plugin, {
+  secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
   cookie: {
-    secure: false,
-  },
+    secure: false
+  }
 });
-app.register(session, {
-  secret: "ABCDEFGHIJKLNMOPQRSTUVWXYZ012345",
-  store: new EmptyStore(),
+app.register(plugin, {
+  secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
+  store: new EmptyStore()
 });
-app.register(session, {
-  secret: "ABCDEFGHIJKLNMOPQRSTUVWXYZ012345",
-  idGenerator: () => Date.now()+"",
+app.register(plugin, {
+  secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
+  idGenerator: () => Date.now() + ''
 });
-expectError(app.register(session, {}));
+expectError(app.register(plugin, {}));
 
 app.route({
-  method: "GET",
-  url: "/",
+  method: 'GET',
+  url: '/',
   preHandler(req, _rep, next) {
     req.destroySession(next);
   },
   async handler(request, reply) {
     expectType<FastifyRequest>(request);
     expectType<FastifyReply>(reply);
-    expectType<Readonly<session.SessionStore>>(request.sessionStore);
+    expectType<Readonly<plugin.SessionStore>>(request.sessionStore);
     expectError((request.sessionStore = null));
     expectError(request.session.doesNotExist());
     expectType<{ id: number } | undefined>(request.session.user);
     request.sessionStore.get('', (err, session) => {
-      expectType<Error>(err)
-      expectType<Session>(session)
-      expectType<{ id: number } | undefined>(session?.user)
-    })
-    expectType<void>(request.session.set('foo', 'bar'))
-    expectType<string>(request.session.get('foo'))
-  },
+      expectType<Error>(err);
+      expectType<Session>(session);
+      expectType<{ id: number } | undefined>(session?.user);
+    });
+    expectType<void>(request.session.set('foo', 'bar'));
+    expectType<string>(request.session.get('foo'));
+  }
 });

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -67,8 +67,8 @@ app.route({
     expectError(request.session.doesNotExist());
     expectType<{ id: number } | undefined>(request.session.user);
     request.sessionStore.get('', (err, session) => {
-      expectType<Error | undefined>(err)
-      expectType<Session | undefined>(session)
+      expectType<Error>(err)
+      expectType<Session>(session)
       expectType<{ id: number } | undefined>(session?.user)
     })
     expectType<void>(request.session.set('foo', 'bar'))


### PR DESCRIPTION
Hello.

This PR aims to :
- fix `CookieOptions` types
- avoid callbacks types bad practices
- make types compatible with `express-session` stores (see: https://github.com/fastify/help/issues/604)

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
