### PR TITLE
idGenerator request object (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Updates the `expires` property of the session.
 
 #### Session#regenerate(request)
 
-Regenerates the session by generating a new `sessionId`. Don't forget to pass the fastify.request object if your id generator uses it.
+Regenerates the session by generating a new `sessionId`. Don't forget to pass the `request` object if the `idGenerator` function parameter uses it.
 ```js
 fastify.get('/regenerate', (request, reply) => {
   request.session.regenerate(request);

--- a/README.md
+++ b/README.md
@@ -88,9 +88,16 @@ Defaults to a simple in-memory store.</br>
 Save sessions to the store, even when they are new and not modified— defaults to `true`.
 Setting this to `false` can save storage space and comply with the EU cookie law.
 
-##### idGenerator (optional)
+##### idGenerator(request) (optional)
 
 Function used to generate new session IDs. Defaults to [`uid(24)`](https://github.com/crypto-utils/uid-safe).
+Custom implementation example:
+```js
+idGenerator: (request) => {
+     if (request.session.returningVisitor) return `returningVisitor-${uid(24)}`
+     else return uid(24)
+}
+```
 
 #### request.session
 
@@ -104,9 +111,15 @@ Allows to destroy the session in the store
 
 Updates the `expires` property of the session.
 
-#### Session#regenerate()
+#### Session#regenerate(request)
 
-Regenerates the session by generating a new `sessionId`.
+Regenerates the session by generating a new `sessionId`. Don't forget to pass the fastify.request object if your id generator uses it.
+```js
+fastify.get('/regenerate', (request, reply) => {
+  request.session.regenerate(request);
+  reply.send(request.session.sessionId);
+});
+```
 
 #### Session#get(key)
 

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -70,6 +70,7 @@ function decryptSession (sessionId, options, request, done) {
       }
       if (options.rolling) {
         request.session = new Session(
+          request,
           idGenerator,
           cookieOpts,
           secret,
@@ -77,6 +78,7 @@ function decryptSession (sessionId, options, request, done) {
         )
       } else {
         request.session = Session.restore(
+          request,
           idGenerator,
           cookieOpts,
           secret,
@@ -142,7 +144,7 @@ function getDestroyCallback (secret, request, done, cookieOpts, idGenerator) {
 }
 
 function newSession (secret, request, cookieOpts, idGenerator, done) {
-  request.session = new Session(idGenerator, cookieOpts, secret)
+  request.session = new Session(request, idGenerator, cookieOpts, secret)
   done()
 }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,7 +10,7 @@ const addDataToSession = Symbol('addDataToSession')
 const generateId = Symbol('generateId')
 
 module.exports = class Session {
-  constructor (idGenerator, cookieOpts, secret, prevSession = {}) {
+  constructor (request, idGenerator, cookieOpts, secret, prevSession = {}) {
     this[generateId] = idGenerator
     this.expires = null
     this.cookie = new Cookie(cookieOpts)
@@ -19,7 +19,7 @@ module.exports = class Session {
     this[addDataToSession](prevSession)
     this.touch()
     if (!this.sessionId) {
-      this.regenerate()
+      this.regenerate(request)
     }
   }
 
@@ -30,8 +30,8 @@ module.exports = class Session {
     }
   }
 
-  regenerate () {
-    this.sessionId = this[generateId]()
+  regenerate (request) {
+    this.sessionId = this[generateId](request)
     this.encryptedSessionId = this[sign]()
   }
 
@@ -55,8 +55,8 @@ module.exports = class Session {
     return cookieSignature.sign(this.sessionId, this[secretKey])
   }
 
-  static restore (idGenerator, cookieOpts, secret, prevSession) {
-    const restoredSession = new Session(idGenerator, cookieOpts, secret, prevSession)
+  static restore (request, idGenerator, cookieOpts, secret, prevSession) {
+    const restoredSession = new Session(request, idGenerator, cookieOpts, secret, prevSession)
     const restoredCookie = new Cookie(cookieOpts)
     restoredCookie.expires = new Date(prevSession.cookie.expires)
     restoredSession.cookie = restoredCookie

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -353,18 +353,8 @@ test('should use custom sessionId generator if available (with request)', async 
     secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
     cookie: { secure: false, maxAge: 10000 },
     idGenerator: (request) => {
-      if (request.session && request.session.returningVisitor) {
-        return `returningVisitor-${
-          new Date().getTime()
-        }-${
-          Math.random().toString().slice(2)
-        }`
-      }
-      return `custom-${
-        new Date().getTime()
-      }-${
-        Math.random().toString().slice(2)
-      }`
+      if (request.session && request.session.returningVisitor) return `returningVisitor-${new Date().getTime()}`
+      else return `custom-${new Date().getTime()}`
     }
   })
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -353,7 +353,7 @@ test('should use custom sessionId generator if available (with request)', async 
     secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
     cookie: { secure: false, maxAge: 10000 },
     idGenerator: (request) => {
-      if (request?.session.returningVisitor) {
+      if (request.session != null && request.session.returningVisitor) {
         return `returningVisitor-${
           new Date().getTime()
         }-${

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -353,7 +353,7 @@ test('should use custom sessionId generator if available (with request)', async 
     secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
     cookie: { secure: false, maxAge: 10000 },
     idGenerator: (request) => {
-      if (request.session != null && request.session.returningVisitor) {
+      if (request.session && request.session.returningVisitor) {
         return `returningVisitor-${
           new Date().getTime()
         }-${
@@ -409,7 +409,7 @@ test('should use custom sessionId generator if available (with request and rolli
     rolling: false,
     cookie: { secure: false, maxAge: 10000 },
     idGenerator: (request) => {
-      if (request.session != null && request.session.returningVisitor) {
+      if (request.session && request.session.returningVisitor) {
         return `returningVisitor-${
           new Date().getTime()
         }-${

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -98,7 +98,7 @@ test('should allow get/set methods for fetching/updating session values', async 
   t.is(response.statusCode, 200)
 })
 
-test('should use custom sessionId generator if available', async (t) => {
+test('should use custom sessionId generator if available (without request)', async (t) => {
   t.plan(2)
   const port = await testServer((request, reply) => {
     t.truthy(request.session.sessionId.startsWith('custom-'))
@@ -167,7 +167,7 @@ test('should generate new sessionId', async (t) => {
   fastify.register(fastifySession, options)
   fastify.get('/', (request, reply) => {
     oldSessionId = request.session.sessionId
-    request.session.regenerate()
+    request.session.regenerate(request)
     reply.send(200)
   })
   fastify.get('/check', (request, reply) => {
@@ -344,4 +344,59 @@ test('should update the expires property of the session using Session#touch() ev
   t.is(response2.statusCode, 200)
 
   t.true(sessionExpires1 !== sessionExpires2)
+})
+
+test('should use custom sessionId generator if available (with request)', async (t) => {
+  const fastify = Fastify()
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
+    cookie: { secure: false, maxAge: 10000 },
+    idGenerator: (request) => {
+      if (request?.session.returningVisitor) {
+        return `returningVisitor-${
+          new Date().getTime()
+        }-${
+          Math.random().toString().slice(2)
+        }`
+      }
+      return `custom-${
+        new Date().getTime()
+      }-${
+        Math.random().toString().slice(2)
+      }`
+    }
+  })
+
+  fastify.get('/', (request, reply) => {
+    reply.status(200).send(request.session.sessionId)
+  })
+  fastify.get('/login', (request, reply) => {
+    request.session.returningVisitor = true
+    request.session.regenerate(request)
+    reply.status(200).send('OK ' + request.session.sessionId)
+  })
+  await fastify.listen(0)
+  fastify.server.unref()
+
+  const { response: response1, body: sessionBody1 } = await request({
+    url: 'http://localhost:' + fastify.server.address().port
+  })
+  t.is(response1.statusCode, 200)
+  t.true(response1.headers['set-cookie'] != null)
+  t.true(sessionBody1.startsWith('custom-'))
+
+  const { response: response2 } = await request({
+    url: 'http://localhost:' + fastify.server.address().port + '/login',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+  t.is(response2.statusCode, 200)
+  t.true(response2.headers['set-cookie'] != null)
+
+  const { response: response3, body: sessionBody3 } = await request({
+    url: 'http://localhost:' + fastify.server.address().port,
+    headers: { Cookie: response2.headers['set-cookie'] }
+  })
+  t.is(response3.statusCode, 200)
+  t.true(sessionBody3.startsWith('returningVisitor-'))
 })

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -104,7 +104,7 @@ declare namespace FastifySessionPlugin {
     rolling?: boolean;
 
     /** Function used to generate new session IDs. Defaults to uid(24). */
-    idGenerator?: (request: Fastify.FastifyRequest) => string;
+    idGenerator?(request?: Fastify.FastifyRequest): string;
   }
 
   interface CookieOptions {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -27,7 +27,7 @@ interface SessionData extends ExpressSessionData {
   touch(): void;
 
   /** Regenerates the session by generating a new `sessionId`. */
-  regenerate(): void;
+  regenerate(request: Fastify.FastifyRequest): void;
 
   /** sets values in the session. */
   set(key: string, value: unknown): void;
@@ -101,7 +101,7 @@ declare namespace FastifySessionPlugin {
     rolling?: boolean;
 
     /** Function used to generate new session IDs. Defaults to uid(24). */
-    idGenerator?: () => string;
+    idGenerator?: (request: Fastify.FastifyRequest) => string;
   }
 
   interface CookieOptions {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -26,8 +26,11 @@ interface SessionData extends ExpressSessionData {
   /** Updates the `expires` property of the session. */
   touch(): void;
 
-  /** Regenerates the session by generating a new `sessionId`. */
-  regenerate(request: Fastify.FastifyRequest): void;
+  /**
+   * Regenerates the session by generating a new `sessionId`.
+   * @param request Optional, but REQUIRED if idGenerator uses it
+   */
+  regenerate(request?: Fastify.FastifyRequest): void;
 
   /** sets values in the session. */
   set(key: string, value: unknown): void;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -52,7 +52,7 @@ app.register(plugin, {
 });
 app.register(plugin, {
   secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
-  idGenerator: (request) => request?.ip + '-' + Date.now()
+  idGenerator: (request) => `${request == undefined ? 'null' : request.ip}-${Date.now()}`
 });
 expectError(app.register(plugin, {}));
 
@@ -75,7 +75,7 @@ app.route({
     request.sessionStore.get('', (err, session) => {
       expectType<Error>(err);
       expectType<Session>(session);
-      expectType<{ id: number } | undefined>(session?.user);
+      expectType<{ id: number } | undefined>(session.user);
     });
     expectType<void>(request.session.set('foo', 'bar'));
     expectType<string>(request.session.get('foo'));

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -50,6 +50,10 @@ app.register(plugin, {
   secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
   idGenerator: () => Date.now() + ''
 });
+app.register(plugin, {
+  secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',
+  idGenerator: (request) => request?.ip + '-' + Date.now()
+});
 expectError(app.register(plugin, {}));
 
 app.route({
@@ -65,6 +69,8 @@ app.route({
     expectError((request.sessionStore = null));
     expectError(request.session.doesNotExist());
     expectType<{ id: number } | undefined>(request.session.user);
+    if(request.session.regenerate) request.session.regenerate();
+    if(request.session.regenerate) request.session.regenerate(request);
     request.sessionStore.set('session-set-test', request.session, () => {})
     request.sessionStore.get('', (err, session) => {
       expectType<Error>(err);


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### What did I do?

Fix for #62 
Added the request object to the idGenerator function for custom scenarios like:
```js
idGenerator: (request) => {
     if (request.session.returningVisitor) return `returningVisitor-${uid(24)}`
     else return uid(24)
}
```