### PR TITLE
chore: fix tests due major ava update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        node-version: [12, 14, 16]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.0",
-    "ava": "^3.6.0",
+    "ava": "^4.1.0",
     "fastify": "^3.0.0",
     "fastify-cookie": "^5.3.1",
     "got": "^11.6.0",

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -5,80 +5,63 @@ const Fastify = require('fastify')
 const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('..')
 
-test.cb('register should fail if no secret is specified', t => {
+test('register should fail if no secret is specified', async t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = {}
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.true(err instanceof Error)
-    t.end()
-  })
+
+  await t.throwsAsync(fastify.ready, { instanceOf: Error, message: 'the secret option is required!' })
 })
 
-test.cb('register should succeed if valid secret is specified', t => {
+test('register should succeed if valid secret is specified', async t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.falsy(err)
-    t.end()
-  })
+  t.truthy(await fastify.ready())
 })
 
-test.cb('register should fail if the secret is too short', t => {
+test('register should fail if the secret is too short', async t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: 'geheim' }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.true(err instanceof Error)
-    t.end()
-  })
+  await t.throwsAsync(fastify.ready, { instanceOf: Error, message: 'the secret must have length 32 or greater' })
 })
 
-test.cb('register should succeed if secret is short, but in an array', t => {
+test('register should succeed if secret is short, but in an array', async t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: ['geheim'] }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.falsy(err)
-    t.end()
-  })
+  t.truthy(await fastify.ready())
 })
 
-test.cb('register should succeed if multiple secrets are present', t => {
+test('register should succeed if multiple secrets are present', async t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: ['geheim', 'test'] }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.falsy(err)
-    t.end()
-  })
+  t.truthy(await fastify.ready())
 })
 
-test.cb('register should fail if no secret is present in array', t => {
+test('register should fail if no secret is present in array', async t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: [] }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.true(err instanceof Error)
-    t.end()
-  })
+  await t.throwsAsync(fastify.ready, { instanceOf: Error, message: 'at least one secret is required' })
 })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -191,18 +191,16 @@ test('should generate new sessionId', async (t) => {
   t.is(response2.statusCode, 200)
 })
 
-test.cb('should decorate the server with decryptSession', t => {
+test('should decorate the server with decryptSession', async t => {
   t.plan(2)
   const fastify = Fastify()
 
   const options = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.ready((err) => {
-    t.falsy(err)
-    t.truthy(fastify.decryptSession)
-    t.end()
-  })
+
+  t.truthy(await fastify.ready())
+  t.truthy(fastify.decryptSession)
 })
 
 test('should decryptSession with custom request object', async (t) => {


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
      
   Ava removed `test.cb` function in ava@4v as you can see on this [doc](https://github.com/avajs/ava/blob/8571b2a7f7ebfefcdc014e7a43b6c874b765b722/docs/02-execution-context.md#tend)
