### PR TITLE
Revert "major: drop node 10 and ava update (#65)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [10, 12, 14, 16]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "ava": "^3.6.0",
     "fastify": "^3.0.0",
     "fastify-cookie": "^5.3.1",
+    "got": "^11.6.0",
     "nyc": "^15.0.0",
     "standard": "^16.0.1",
     "tsd": "^0.19.0",
-    "typescript": "^4.0.2",
-    "undici": "^4.16.0"
+    "typescript": "^4.0.2"
   },
   "types": "types/types.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.0",
-    "ava": "^4.1.0",
+    "ava": "^3.6.0",
     "fastify": "^3.0.0",
     "fastify-cookie": "^5.3.1",
     "nyc": "^15.0.0",

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -5,63 +5,80 @@ const Fastify = require('fastify')
 const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('..')
 
-test('register should fail if no secret is specified', async t => {
+test.cb('register should fail if no secret is specified', t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = {}
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-
-  await t.throwsAsync(fastify.ready, { instanceOf: Error, message: 'the secret option is required!' })
+  fastify.ready((err) => {
+    t.true(err instanceof Error)
+    t.end()
+  })
 })
 
-test('register should succeed if valid secret is specified', async t => {
+test.cb('register should succeed if valid secret is specified', t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  t.truthy(await fastify.ready())
+  fastify.ready((err) => {
+    t.falsy(err)
+    t.end()
+  })
 })
 
-test('register should fail if the secret is too short', async t => {
+test.cb('register should fail if the secret is too short', t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: 'geheim' }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  await t.throwsAsync(fastify.ready, { instanceOf: Error, message: 'the secret must have length 32 or greater' })
+  fastify.ready((err) => {
+    t.true(err instanceof Error)
+    t.end()
+  })
 })
 
-test('register should succeed if secret is short, but in an array', async t => {
+test.cb('register should succeed if secret is short, but in an array', t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: ['geheim'] }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  t.truthy(await fastify.ready())
+  fastify.ready((err) => {
+    t.falsy(err)
+    t.end()
+  })
 })
 
-test('register should succeed if multiple secrets are present', async t => {
+test.cb('register should succeed if multiple secrets are present', t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: ['geheim', 'test'] }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  t.truthy(await fastify.ready())
+  fastify.ready((err) => {
+    t.falsy(err)
+    t.end()
+  })
 })
 
-test('register should fail if no secret is present in array', async t => {
+test.cb('register should fail if no secret is present in array', t => {
   t.plan(1)
   const fastify = Fastify()
 
   const options = { secret: [] }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  await t.throwsAsync(fastify.ready, { instanceOf: Error, message: 'at least one secret is required' })
+  fastify.ready((err) => {
+    t.true(err instanceof Error)
+    t.end()
+  })
 })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -191,16 +191,18 @@ test('should generate new sessionId', async (t) => {
   t.is(response2.statusCode, 200)
 })
 
-test('should decorate the server with decryptSession', async t => {
+test.cb('should decorate the server with decryptSession', t => {
   t.plan(2)
   const fastify = Fastify()
 
   const options = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-
-  t.truthy(await fastify.ready())
-  t.truthy(fastify.decryptSession)
+  fastify.ready((err) => {
+    t.falsy(err)
+    t.truthy(fastify.decryptSession)
+    t.end()
+  })
 })
 
 test('should decryptSession with custom request object', async (t) => {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -373,7 +373,7 @@ test('should use custom sessionId generator if available (with request)', async 
     url: 'http://localhost:' + fastify.server.address().port
   })
   t.is(response1.statusCode, 200)
-  t.true(response1.headers['set-cookie'] !== undefined)
+  t.true(response1.headers['set-cookie'] != null)
   t.true(sessionBody1.startsWith('custom-'))
 
   const { response: response2 } = await request({
@@ -381,7 +381,7 @@ test('should use custom sessionId generator if available (with request)', async 
     headers: { Cookie: response1.headers['set-cookie'] }
   })
   t.is(response2.statusCode, 200)
-  t.true(response2.headers['set-cookie'] !== undefined)
+  t.true(response2.headers['set-cookie'] != null)
 
   const { response: response3, body: sessionBody3 } = await request({
     url: 'http://localhost:' + fastify.server.address().port,
@@ -429,7 +429,7 @@ test('should use custom sessionId generator if available (with request and rolli
     url: 'http://localhost:' + fastify.server.address().port
   })
   t.is(response1.statusCode, 200)
-  t.true(response1.headers['set-cookie'] !== undefined)
+  t.true(response1.headers['set-cookie'] != null)
   t.true(sessionBody1.startsWith('custom-'))
 
   const { response: response2 } = await request({
@@ -437,7 +437,7 @@ test('should use custom sessionId generator if available (with request and rolli
     headers: { Cookie: response1.headers['set-cookie'] }
   })
   t.is(response2.statusCode, 200)
-  t.true(response2.headers['set-cookie'] !== undefined)
+  t.true(response2.headers['set-cookie'] != null)
 
   const { response: response3, body: sessionBody3 } = await request({
     url: 'http://localhost:' + fastify.server.address().port,

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -103,7 +103,7 @@ test('should set new session cookie if expired', async (t) => {
   })
 
   t.is(statusCode, 500)
-  t.is(cookie, undefined)
+  t.is(cookie, null)
 })
 
 test('store should be an event emitter', t => {

--- a/test/util.js
+++ b/test/util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Fastify = require('fastify')
-const undici = require('undici')
+const got = require('got')
 const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('../lib/fastifySession')
 
@@ -23,19 +23,14 @@ async function testServer (handler, sessionOptions, plugin) {
 
 async function request (options) {
   let response
-  let body
   try {
-    if (typeof options === 'string') {
-      response = await undici.request(options)
-    } else {
-      response = await undici.request(options.url, options)
-    }
-    body = await response.body.text()
+    response = await got(options)
   } catch (err) {
     response = err.response
   }
-  const { statusCode } = response
-  const cookie = response.headers['set-cookie']
+  const { statusCode, body } = response
+  const cookieHeader = response.headers['set-cookie']
+  const cookie = cookieHeader ? cookieHeader[0] : null
   return { response, body, statusCode, cookie }
 }
 


### PR DESCRIPTION
This reverts commit da33d5dc8ce8f722092db9fd85c33724e73f0b77.

This PR target to `6.x` branch and revert the drop support changes as I release the wrong version number.
It should not drop the support of node 10 for `6.x`.

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
