### PR TITLE
feat: remove stale cookies

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -128,7 +128,16 @@ function onRequest (options) {
 function onSend (options) {
   return function saveSession (request, reply, payload, done) {
     const session = request.session
-    if (!session || !session.sessionId || !shouldSaveSession(request, options.cookie, options.saveUninitialized)) {
+    if (!session || !session.sessionId) {
+      done()
+      return
+    }
+
+    if (!shouldSaveSession(request, options.cookie, options.saveUninitialized)) {
+      // if a session cookie is set, but has a different ID, clear it
+      if (request.cookies[options.cookieName] && request.cookies[options.cookieName] !== session.encryptedSessionId) {
+        reply.clearCookie(options.cookieName)
+      }
       done()
       return
     }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -4,7 +4,7 @@ const test = require('ava')
 const Fastify = require('fastify')
 const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('..')
-const { request, testServer, DEFAULT_OPTIONS, DEFAULT_COOKIE } = require('./util')
+const { request, testServer, DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_COOKIE_VALUE } = require('./util')
 
 test('should add session object to request', async (t) => {
   t.plan(2)
@@ -675,4 +675,34 @@ test('save supports rejecting promises', async t => {
 
   // 200 since we assert inline and swallow the error
   t.is(response.statusCode, 200)
+})
+
+test("clears cookie if not backed by a session, and there's nothing to save", async t => {
+  t.plan(2)
+  const port = await testServer((request, reply) => {
+    reply.send(200)
+  }, DEFAULT_OPTIONS)
+
+  const { response, cookie } = await request({
+    url: `http://localhost:${port}`,
+    headers: { cookie: DEFAULT_COOKIE_VALUE }
+  })
+
+  t.is(response.statusCode, 200)
+  t.is(cookie, 'sessionId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+})
+
+test('does not clear cookie if no session cookie in request', async t => {
+  t.plan(2)
+  const port = await testServer((request, reply) => {
+    reply.send(200)
+  }, DEFAULT_OPTIONS)
+
+  const { response, cookie } = await request({
+    url: `http://localhost:${port}`,
+    headers: { cookie: 'someOtherCookie=foobar' }
+  })
+
+  t.is(response.statusCode, 200)
+  t.is(cookie, undefined)
 })

--- a/test/util.js
+++ b/test/util.js
@@ -6,7 +6,8 @@ const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('../lib/fastifySession')
 
 const DEFAULT_OPTIONS = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
-const DEFAULT_COOKIE = 'sessionId=Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE; Path=/; HttpOnly; Secure'
+const DEFAULT_COOKIE_VALUE = 'sessionId=Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE'
+const DEFAULT_COOKIE = `${DEFAULT_COOKIE_VALUE}; Path=/; HttpOnly; Secure`
 
 async function testServer (handler, sessionOptions, plugin) {
   const fastify = Fastify()
@@ -42,6 +43,7 @@ async function request (options) {
 module.exports = {
   testServer,
   request,
+  DEFAULT_COOKIE_VALUE,
   DEFAULT_COOKIE,
   DEFAULT_OPTIONS
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

I noticed while using a memory storage that the old session cookie was kept around. Doesn't really hurt, but it confused me when I was debugging why my session wasn't working