### PR TITLE
Add cookiePrefix as an option to allow for compatibility with express-session

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -107,6 +107,7 @@ function onRequest (options) {
   const unsignSignedCookie = options.unsignSignedCookie
   const cookieOpts = options.cookie
   const idGenerator = options.idGenerator
+  const cookiePrefix = options.cookiePrefix
   return function handleSession (request, reply, done) {
     request.session = {}
 
@@ -115,7 +116,10 @@ function onRequest (options) {
       done()
       return
     }
-    const sessionId = request.cookies[options.cookieName]
+    let sessionId = request.cookies[options.cookieName]
+    if (sessionId && cookiePrefix && sessionId.slice(0, cookiePrefix.length) === cookiePrefix) {
+      sessionId = sessionId.slice(cookiePrefix.length)
+    }
     const secret = options.secret[0]
     if (!sessionId) {
       newSession(secret, request, cookieOpts, idGenerator, done)
@@ -142,9 +146,14 @@ function onSend (options) {
       return
     }
 
+    let encryptedSessionId = session.encryptedSessionId;
+    if (encryptedSessionId) {
+      encryptedSessionId = `${options.cookiePrefix}${encryptedSessionId}`
+    }
+
     if (!shouldSaveSession(request, options.cookie, options.saveUninitialized)) {
       // if a session cookie is set, but has a different ID, clear it
-      if (request.cookies[options.cookieName] && request.cookies[options.cookieName] !== session.encryptedSessionId) {
+      if (request.cookies[options.cookieName] && request.cookies[options.cookieName] !== encryptedSessionId) {
         reply.clearCookie(options.cookieName)
       }
       done()
@@ -157,7 +166,7 @@ function onSend (options) {
       }
       reply.setCookie(
         options.cookieName,
-        session.encryptedSessionId,
+        encryptedSessionId,
         session.cookie.options(isConnectionSecure(request))
       )
       done()
@@ -196,6 +205,7 @@ function ensureDefaults (options) {
   options.rolling = option(options, 'rolling', true)
   options.saveUninitialized = option(options, 'saveUninitialized', true)
   options.secret = Array.isArray(options.secret) ? options.secret : [options.secret]
+  options.cookiePrefix = option(options, 'cookiePrefix', '')
   return options
 }
 

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -122,6 +122,12 @@ declare namespace FastifySessionPlugin {
 
     /** Function used to generate new session IDs. Defaults to uid(24). */
     idGenerator?(request?: Fastify.FastifyRequest): string;
+
+    /**
+     * Prefixes all cookie values. Run with "s:" to be be compatible with express-session.
+     * Defaults to false.
+     */
+     cookiePrefix?: string;
   }
 
   interface CookieOptions {


### PR DESCRIPTION
It's worth mentioning that @fastify/session will still not be perfectly compatible with express-session until this is fixed:
https://github.com/fastify/session/pull/101

express-session does not put sessionId inside the actual session

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
