### PR TITLE
Remove session id and encrypted session id from session data

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Allows to destroy the session in the store. If you do not pass a callback, a Pro
 
 #### Session#touch()
 
-Updates the `expires` property of the session.
+Updates the `expires` property of the session's cookie.
 
 #### Session#regenerate(callback)
 

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -62,7 +62,7 @@ function decryptSession (sessionId, options, request, done) {
         newSession(secret, request, cookieOpts, idGenerator, done)
         return
       }
-      if (session?.cookie?.expires && session.cookie.expires <= new Date()) {
+      if (session.cookie?.expires && session.cookie.expires <= Date.now()) {
         const restoredSession = Session.restore(
           request,
           idGenerator,

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -62,7 +62,7 @@ function decryptSession (sessionId, options, request, done) {
         newSession(secret, request, cookieOpts, idGenerator, done)
         return
       }
-      if (session?.expires && session.expires <= Date.now()) {
+      if (session?.cookie?.expires && session.cookie.expires <= Date.now()) {
         const restoredSession = Session.restore(
           request,
           idGenerator,

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -68,7 +68,8 @@ function decryptSession (sessionId, options, request, done) {
           idGenerator,
           cookieOpts,
           secret,
-          session
+          session,
+          decryptedSessionId
         )
 
         restoredSession.destroy(err => {
@@ -87,7 +88,8 @@ function decryptSession (sessionId, options, request, done) {
           idGenerator,
           cookieOpts,
           secret,
-          session
+          session,
+          decryptedSessionId
         )
       } else {
         request.session = Session.restore(
@@ -95,7 +97,8 @@ function decryptSession (sessionId, options, request, done) {
           idGenerator,
           cookieOpts,
           secret,
-          session
+          session,
+          decryptedSessionId
         )
       }
       done()

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -62,7 +62,7 @@ function decryptSession (sessionId, options, request, done) {
         newSession(secret, request, cookieOpts, idGenerator, done)
         return
       }
-      if (session?.cookie?.expires && session.cookie.expires <= Date.now()) {
+      if (session?.cookie?.expires && session.cookie.expires <= new Date()) {
         const restoredSession = Session.restore(
           request,
           idGenerator,

--- a/lib/session.js
+++ b/lib/session.js
@@ -22,7 +22,6 @@ const encryptedSessionIdKey = Symbol('encryptedSessionId')
 module.exports = class Session {
   constructor (request, idGenerator, cookieOpts, secret, prevSession = {}, sessionId = idGenerator(request)) {
     this[generateId] = idGenerator
-    this.expires = null
     this.cookie = new Cookie(cookieOpts)
     this[cookieOptsKey] = cookieOpts
     this[maxAge] = cookieOpts.maxAge
@@ -37,8 +36,7 @@ module.exports = class Session {
 
   touch () {
     if (this[maxAge]) {
-      this.expires = new Date(Date.now() + this[maxAge])
-      this.cookie.expires = this.expires
+      this.cookie.expires = new Date(Date.now() + this[maxAge])
     }
   }
 
@@ -70,7 +68,7 @@ module.exports = class Session {
 
   [addDataToSession] (prevSession) {
     for (const key in prevSession) {
-      if (!['expires', 'cookie', 'sessionId', 'encryptedSessionId'].includes(key)) {
+      if (!['cookie', 'sessionId', 'encryptedSessionId'].includes(key)) {
         this[key] = prevSession[key]
       }
     }
@@ -151,7 +149,8 @@ module.exports = class Session {
     const str = stringify(sess, function (key, val) {
       // ignore sess.cookie property
       if (this === sess && key === 'cookie') {
-        return
+        // we want `touch` to affect the hash of the session
+        return sess.cookie.expires
       }
 
       return val
@@ -178,9 +177,8 @@ module.exports = class Session {
   static restore (request, idGenerator, cookieOpts, secret, prevSession, sessionId) {
     const restoredSession = new Session(request, idGenerator, cookieOpts, secret, prevSession, sessionId)
     const restoredCookie = new Cookie(cookieOpts)
-    restoredCookie.expires = new Date(prevSession.expires)
+    restoredCookie.expires = new Date(prevSession.cookie.expires)
     restoredSession.cookie = restoredCookie
-    restoredSession.expires = restoredCookie.expires
     restoredSession[originalHash] = restoredSession[hash]()
     return restoredSession
   }

--- a/lib/session.js
+++ b/lib/session.js
@@ -70,7 +70,7 @@ module.exports = class Session {
 
   [addDataToSession] (prevSession) {
     for (const key in prevSession) {
-      if (!['expires', 'cookie'].includes(key)) {
+      if (!['expires', 'cookie', 'sessionId', 'encryptedSessionId'].includes(key)) {
         this[key] = prevSession[key]
       }
     }

--- a/lib/session.js
+++ b/lib/session.js
@@ -10,16 +10,17 @@ const stringify = configureStringifier({ bigint: false })
 
 const maxAge = Symbol('maxAge')
 const secretKey = Symbol('secretKey')
-const sign = Symbol('sign')
 const addDataToSession = Symbol('addDataToSession')
 const generateId = Symbol('generateId')
 const requestKey = Symbol('request')
 const cookieOptsKey = Symbol('cookieOpts')
 const originalHash = Symbol('originalHash')
 const hash = Symbol('hash')
+const sessionIdKey = Symbol('sessionId')
+const encryptedSessionIdKey = Symbol('encryptedSessionId')
 
 module.exports = class Session {
-  constructor (request, idGenerator, cookieOpts, secret, prevSession = {}) {
+  constructor (request, idGenerator, cookieOpts, secret, prevSession = {}, sessionId = idGenerator(request)) {
     this[generateId] = idGenerator
     this.expires = null
     this.cookie = new Cookie(cookieOpts)
@@ -29,10 +30,8 @@ module.exports = class Session {
     this[addDataToSession](prevSession)
     this[requestKey] = request
     this.touch()
-    if (!this.sessionId) {
-      this.sessionId = this[generateId](this[requestKey])
-      this.encryptedSessionId = this[sign]()
-    }
+    this[sessionIdKey] = sessionId
+    this[encryptedSessionIdKey] = cookieSignature.sign(this[sessionIdKey], secret)
     this[originalHash] = this[hash]()
   }
 
@@ -87,14 +86,14 @@ module.exports = class Session {
 
   destroy (callback) {
     if (callback) {
-      this[requestKey].sessionStore.destroy(this.sessionId, error => {
+      this[requestKey].sessionStore.destroy(this[sessionIdKey], error => {
         this[requestKey].session = null
 
         callback(error)
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[requestKey].sessionStore.destroy(this.sessionId, error => {
+        this[requestKey].sessionStore.destroy(this[sessionIdKey], error => {
           this[requestKey].session = null
 
           if (error) {
@@ -109,15 +108,15 @@ module.exports = class Session {
 
   reload (callback) {
     if (callback) {
-      this[requestKey].sessionStore.get(this.sessionId, (error, session) => {
-        this[requestKey].session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[secretKey], session)
+      this[requestKey].sessionStore.get(this[sessionIdKey], (error, session) => {
+        this[requestKey].session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[secretKey], session, this[sessionIdKey])
 
         callback(error)
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[requestKey].sessionStore.get(this.sessionId, (error, session) => {
-          this[requestKey].session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[secretKey], session)
+        this[requestKey].sessionStore.get(this[sessionIdKey], (error, session) => {
+          this[requestKey].session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[secretKey], session, this[sessionIdKey])
 
           if (error) {
             reject(error)
@@ -131,12 +130,12 @@ module.exports = class Session {
 
   save (callback) {
     if (callback) {
-      this[requestKey].sessionStore.set(this.sessionId, this, error => {
+      this[requestKey].sessionStore.set(this[sessionIdKey], this, error => {
         callback(error)
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[requestKey].sessionStore.set(this.sessionId, this, error => {
+        this[requestKey].sessionStore.set(this[sessionIdKey], this, error => {
           if (error) {
             reject(error)
           } else {
@@ -145,10 +144,6 @@ module.exports = class Session {
         })
       })
     }
-  }
-
-  [sign] () {
-    return cookieSignature.sign(this.sessionId, this[secretKey])
   }
 
   [hash] () {
@@ -172,10 +167,18 @@ module.exports = class Session {
     return this[originalHash] !== this[hash]()
   }
 
-  static restore (request, idGenerator, cookieOpts, secret, prevSession) {
-    const restoredSession = new Session(request, idGenerator, cookieOpts, secret, prevSession)
+  get sessionId () {
+    return this[sessionIdKey]
+  }
+
+  get encryptedSessionId () {
+    return this[encryptedSessionIdKey]
+  }
+
+  static restore (request, idGenerator, cookieOpts, secret, prevSession, sessionId) {
+    const restoredSession = new Session(request, idGenerator, cookieOpts, secret, prevSession, sessionId)
     const restoredCookie = new Cookie(cookieOpts)
-    restoredCookie.expires = new Date(prevSession.cookie.expires)
+    restoredCookie.expires = new Date(prevSession.expires)
     restoredSession.cookie = restoredCookie
     restoredSession.expires = restoredCookie.expires
     restoredSession[originalHash] = restoredSession[hash]()

--- a/lib/session.js
+++ b/lib/session.js
@@ -28,10 +28,10 @@ module.exports = class Session {
     this[secretKey] = secret
     this[addDataToSession](prevSession)
     this[requestKey] = request
-    this.touch()
     this[sessionIdKey] = sessionId
     this[encryptedSessionIdKey] = cookieSignature.sign(sessionId, secret)
     this[originalHash] = this[hash]()
+    this.touch()
   }
 
   touch () {
@@ -150,7 +150,7 @@ module.exports = class Session {
       // ignore sess.cookie property
       if (this === sess && key === 'cookie') {
         // we want `touch` to affect the hash of the session
-        return sess.cookie.expires
+        return sess.cookie.expires?.toISOString()
       }
 
       return val

--- a/lib/session.js
+++ b/lib/session.js
@@ -163,7 +163,13 @@ module.exports = class Session {
   }
 
   isModified () {
-    return this[originalHash] !== this[hash]()
+    return Boolean(
+      this[originalHash] !== this[hash]() ||
+      // If maxAge is set, the session is modified.
+      // This is necessary because we don't read the cookie's expiration from the cookie itself.
+      // session.cookie.expires is initially set from Cookie(cookieOpts), so we cannot detect if it changed from maxAge alone.
+      this[maxAge]
+    )
   }
 
   get sessionId () {

--- a/lib/session.js
+++ b/lib/session.js
@@ -150,7 +150,7 @@ module.exports = class Session {
       // ignore sess.cookie property
       if (this === sess && key === 'cookie') {
         // we want `touch` to affect the hash of the session
-        return sess.cookie.expires?.toISOString()
+        return sess.cookie.expires?.getTime()
       }
 
       return val

--- a/lib/session.js
+++ b/lib/session.js
@@ -31,7 +31,7 @@ module.exports = class Session {
     this[requestKey] = request
     this.touch()
     this[sessionIdKey] = sessionId
-    this[encryptedSessionIdKey] = cookieSignature.sign(this[sessionIdKey], secret)
+    this[encryptedSessionIdKey] = cookieSignature.sign(sessionId, secret)
     this[originalHash] = this[hash]()
   }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -31,7 +31,7 @@ module.exports = class Session {
     this[sessionIdKey] = sessionId
     this[encryptedSessionIdKey] = cookieSignature.sign(sessionId, secret)
     this[originalHash] = this[hash]()
-    this.touch()
+    this.touch() // Needs to happen after originalHash is set, in case maxAge forces an update
   }
 
   touch () {

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -102,7 +102,6 @@ test('should set session cookie using the default cookie name', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
         cookie: { expires: Date.now() + 1000, secure: true, httpOnly: true, path: '/' }
       }, done)
     })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -2,7 +2,7 @@
 
 const test = require('tap').test
 const fastifyPlugin = require('fastify-plugin')
-const { DEFAULT_OPTIONS, DEFAULT_COOKIE, buildFastify } = require('./util')
+const { DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_COOKIE_VALUE, DEFAULT_SESSION_ID, buildFastify } = require('./util')
 
 test('should not set session cookie on post without params', async (t) => {
   t.plan(3)
@@ -114,7 +114,7 @@ test('should set session cookie using the default cookie name', async (t) => {
   t.plan(2)
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         cookie: { secure: true, httpOnly: true, path: '/' }
       }, done)
     })
@@ -142,8 +142,7 @@ test('should create new session on expired session', async (t) => {
   t.plan(2)
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         cookie: { expires: new Date(Date.now() - 1000), secure: true, httpOnly: true, path: '/' }
       }, done)
     })
@@ -178,7 +177,7 @@ test('should set session.cookie.expires if maxAge', async (t) => {
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         test: {}
       }, done)
     })
@@ -205,7 +204,7 @@ test('should set new session cookie if expired', async (t) => {
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         cookie: { expires: new Date(Date.now() - 1000) }
       }, done)
     })
@@ -224,7 +223,7 @@ test('should set new session cookie if expired', async (t) => {
     }
   })
 
-  t.equal(response.headers['set-cookie'].includes('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE'), false)
+  t.equal(response.headers['set-cookie'].includes(DEFAULT_COOKIE_VALUE), false)
   t.match(response.headers['set-cookie'], /sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure/)
   t.equal(response.statusCode, 200)
 })
@@ -247,7 +246,7 @@ test('should return new session cookie if does not exist in store', async (t) =>
   })
 
   t.equal(response.statusCode, 200)
-  t.equal(response.headers['set-cookie'].includes('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE'), false)
+  t.equal(response.headers['set-cookie'].includes(DEFAULT_COOKIE_VALUE), false)
   t.match(response.headers['set-cookie'], /sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure/)
 })
 
@@ -278,7 +277,7 @@ test('should create new session if cookie contains invalid session', async (t) =
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         test: {}
       }, done)
     })
@@ -325,7 +324,7 @@ test('should not set session cookie if saveUninitialized is false and data in se
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         test: {}
       }, done)
     })
@@ -335,7 +334,7 @@ test('should not set session cookie if saveUninitialized is false and data in se
 
   const response = await fastify.inject({
     url: '/',
-    headers: { 'x-forwarded-proto': 'https' }
+    headers: { cookie: DEFAULT_COOKIE, 'x-forwarded-proto': 'https' }
   })
 
   t.equal(response.statusCode, 200)
@@ -353,7 +352,7 @@ test('should set session cookie if saveUninitialized is false and maxAge is on',
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      request.sessionStore.set(DEFAULT_SESSION_ID, {
         // In this scenario, maxAge would have set expires in a previous request
         expires: new Date(Date.now() + 1000)
       }, done)
@@ -364,7 +363,7 @@ test('should set session cookie if saveUninitialized is false and maxAge is on',
 
   const response = await fastify.inject({
     url: '/',
-    headers: { 'x-forwarded-proto': 'https' }
+    headers: { cookie: DEFAULT_COOKIE, 'x-forwarded-proto': 'https' }
   })
 
   t.equal(response.statusCode, 200)

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -105,6 +105,7 @@ test('should set session cookie using the default cookie name', async (t) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() + 1000,
+        sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
         cookie: { secure: true, httpOnly: true, path: '/' }
       }, done)
     })
@@ -134,6 +135,7 @@ test('should create new session on expired session', async (t) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() - 1000,
+        sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
         cookie: { secure: true, httpOnly: true, path: '/' }
       }, done)
     })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -52,10 +52,8 @@ test('should support multiple secrets', async (t) => {
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      const expires = Date.now() - 1000
       request.sessionStore.set('aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e', {
-        cookie: { expires },
-        expires
+        cookie: { expires: Date.now() - 1000 }
       }, done)
     })
   })
@@ -104,9 +102,8 @@ test('should set session cookie using the default cookie name', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        expires: Date.now() + 1000,
         sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
-        cookie: { secure: true, httpOnly: true, path: '/' }
+        cookie: { expires: Date.now() + 1000, secure: true, httpOnly: true, path: '/' }
       }, done)
     })
   })
@@ -134,9 +131,8 @@ test('should create new session on expired session', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        expires: Date.now() - 1000,
         sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
-        cookie: { secure: true, httpOnly: true, path: '/' }
+        cookie: { expires: Date.now() - 1000, secure: true, httpOnly: true, path: '/' }
       }, done)
     })
   })
@@ -171,12 +167,12 @@ test('should set session.expires if maxAge', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        expires: Date.now() + 1000
+        cookie: { expires: Date.now() + 1000 }
       }, done)
     })
   })
   function handler (request, reply) {
-    t.ok(request.session.expires)
+    t.ok(request.session.cookie.expires)
     reply.send(200)
   }
   const fastify = await buildFastify(handler, options, plugin)
@@ -195,10 +191,8 @@ test('should set new session cookie if expired', async (t) => {
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
-      const expires = Date.now() - 1000
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        cookie: { expires },
-        expires
+        cookie: { expires: Date.now() - 1000 }
       }, done)
     })
   })
@@ -272,7 +266,7 @@ test('should create new session if cookie contains invalid session', async (t) =
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        expires: Date.now() + 1000
+        cookie: { expires: Date.now() + 1000 }
       }, done)
     })
   })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -52,8 +52,10 @@ test('should support multiple secrets', async (t) => {
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
+      const expires = Date.now() - 1000
       request.sessionStore.set('aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e', {
-        expires: Date.now() + 1000
+        cookie: { expires },
+        expires
       }, done)
     })
   })
@@ -103,7 +105,6 @@ test('should set session cookie using the default cookie name', async (t) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() + 1000,
-        sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
         cookie: { secure: true, httpOnly: true, path: '/' }
       }, done)
     })
@@ -124,7 +125,7 @@ test('should set session cookie using the default cookie name', async (t) => {
   })
 
   t.equal(response.statusCode, 200)
-  t.match(response.headers['set-cookie'], /sessionId=undefined; Path=\/; HttpOnly; Secure/)
+  t.match(response.headers['set-cookie'], /sessionId=.*\..*; Path=\/; HttpOnly; Secure/)
 })
 
 test('should create new session on expired session', async (t) => {
@@ -133,7 +134,6 @@ test('should create new session on expired session', async (t) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() - 1000,
-        sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
         cookie: { secure: true, httpOnly: true, path: '/' }
       }, done)
     })
@@ -193,8 +193,10 @@ test('should set new session cookie if expired', async (t) => {
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
+      const expires = Date.now() - 1000
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        expires: Date.now() + 1000
+        cookie: { expires },
+        expires
       }, done)
     })
   })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -64,8 +64,8 @@ test('should support multiple secrets', async (t) => {
   const fastify = await buildFastify(handler, options, plugin)
   t.teardown(() => fastify.close())
 
-  const sessionIdEncryptedWithOldSecret = "aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e.eiVu2YbrcqbTUYTYaANks%2Fjn%2Bjta7QgpsxLO%2BOLN%2F4U"
-  const sessionIdEncryptedWithNewSecret = "aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e.InCp31AuDa7DX%2F8rGBz8RMFiCpmUtjcF%2BS7Aco7tur8"
+  const sessionIdEncryptedWithOldSecret = 'aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e.eiVu2YbrcqbTUYTYaANks%2Fjn%2Bjta7QgpsxLO%2BOLN%2F4U'
+  const sessionIdEncryptedWithNewSecret = 'aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e.InCp31AuDa7DX%2F8rGBz8RMFiCpmUtjcF%2BS7Aco7tur8'
 
   const responseForOldSecret = await fastify.inject({
     url: '/',
@@ -192,7 +192,7 @@ test('should set session.cookie.expires if maxAge', async (t) => {
 
   const response = await fastify.inject({
     url: '/',
-    headers: { cookie: DEFAULT_COOKIE, 'x-forwarded-proto': 'https'},
+    headers: { cookie: DEFAULT_COOKIE, 'x-forwarded-proto': 'https' }
   })
 
   t.equal(response.statusCode, 200)
@@ -329,7 +329,7 @@ test('should set session cookie if saveUninitialized is false and data not modif
   }
   const fastify = await buildFastify((request, reply) => reply.send(200), options)
   t.teardown(() => fastify.close())
-  
+
   const response = await fastify.inject({
     url: '/',
     headers: { 'x-forwarded-proto': 'https' }
@@ -338,4 +338,3 @@ test('should set session cookie if saveUninitialized is false and data not modif
   t.equal(response.statusCode, 200)
   t.ok(response.headers['set-cookie'])
 })
-

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -354,7 +354,9 @@ test('should set session cookie if saveUninitialized is false and maxAge is on',
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set(DEFAULT_SESSION_ID, {
         // In this scenario, maxAge would have set expires in a previous request
-        expires: new Date(Date.now() + 1000)
+        cookie: {
+          expires: new Date(Date.now() + 1000)
+        }
       }, done)
     })
   })

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -196,7 +196,6 @@ test('should set new session cookie if expired', async (t) => {
     })
   })
   function handler (request, reply) {
-    request.session.test = {}
     reply.send(200)
   }
   const fastify = await buildFastify(handler, DEFAULT_OPTIONS, plugin)

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -251,6 +251,7 @@ test('should decryptSession with custom request object', async (t) => {
     request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
       testData: 'this is a test',
       expires: Date.now() + 1000,
+      sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
       cookie: { secure: true, httpOnly: true, path: '/' }
     }, done)
   })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -231,7 +231,6 @@ test('should decryptSession with custom request object', async (t) => {
   fastify.addHook('onRequest', (request, reply, done) => {
     request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
       testData: 'this is a test',
-      sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
       cookie: { expires: Date.now() + 1000, secure: true, httpOnly: true, path: '/' }
     }, done)
   })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -42,9 +42,11 @@ test('should destroy the session', async (t) => {
 })
 
 test('should add session.encryptedSessionId object to request', async (t) => {
-  t.plan(2)
+  t.plan(3)
   const fastify = await buildFastify((request, reply) => {
     t.ok(request.session.encryptedSessionId)
+    // serialize, then deserialize to make sure it's gone
+    t.falsy(JSON.parse(JSON.stringify(request.session)).encryptedSessionId)
     reply.send(200)
   }, DEFAULT_OPTIONS)
   t.teardown(() => fastify.close())
@@ -249,7 +251,6 @@ test('should decryptSession with custom request object', async (t) => {
     request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
       testData: 'this is a test',
       expires: Date.now() + 1000,
-      sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
       cookie: { secure: true, httpOnly: true, path: '/' }
     }, done)
   })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -46,7 +46,7 @@ test('should add session.encryptedSessionId object to request', async (t) => {
   const fastify = await buildFastify((request, reply) => {
     t.ok(request.session.encryptedSessionId)
     // serialize, then deserialize to make sure it's gone
-    t.falsy(JSON.parse(JSON.stringify(request.session)).encryptedSessionId)
+    t.notOk(JSON.parse(JSON.stringify(request.session)).encryptedSessionId)
     reply.send(200)
   }, DEFAULT_OPTIONS)
   t.teardown(() => fastify.close())

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -231,7 +231,7 @@ test('should decryptSession with custom request object', async (t) => {
   fastify.addHook('onRequest', (request, reply, done) => {
     request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
       testData: 'this is a test',
-      cookie: { expires: Date.now() + 1000, secure: true, httpOnly: true, path: '/' }
+      cookie: { secure: true, httpOnly: true, path: '/' }
     }, done)
   })
 
@@ -290,7 +290,7 @@ test('should bubble up errors with destroy call if session expired', async (t) =
   const store = {
     set (id, data, cb) { cb(null) },
     get (id, cb) {
-      cb(null, { cookie: { expires: Date.now() - 1000 } })
+      cb(null, { cookie: { expires: new Date(Date.now() - 1000) } })
     },
     destroy (id, cb) { cb(new Error('No can do')) }
   }

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -101,7 +101,7 @@ test('should set new session cookie if expired', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-      cookie: {expires: Date.now() - 1000}
+        cookie: { expires: Date.now() - 1000 }
       }, done)
     })
   })

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -101,7 +101,7 @@ test('should set new session cookie if expired', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        cookie: { expires: Date.now() - 1000 }
+        cookie: { expires: new Date(Date.now() - 1000) }
       }, done)
     })
   })

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -101,7 +101,7 @@ test('should set new session cookie if expired', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
-        expires: Date.now() - 1000
+      cookie: {expires: Date.now() - 1000}
       }, done)
     })
   })

--- a/test/util.js
+++ b/test/util.js
@@ -5,7 +5,8 @@ const fastifyCookie = require('@fastify/cookie')
 const fastifySession = require('../lib/fastifySession')
 
 const DEFAULT_OPTIONS = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
-const DEFAULT_COOKIE_VALUE = 'sessionId=Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE'
+const DEFAULT_SESSION_ID = 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN'
+const DEFAULT_COOKIE_VALUE = `sessionId=${DEFAULT_SESSION_ID}.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE`
 const DEFAULT_COOKIE = `${DEFAULT_COOKIE_VALUE}; Path=/; HttpOnly; Secure`
 
 async function buildFastify (handler, sessionOptions, plugin) {
@@ -25,5 +26,6 @@ module.exports = {
   buildFastify,
   DEFAULT_COOKIE_VALUE,
   DEFAULT_COOKIE,
-  DEFAULT_OPTIONS
+  DEFAULT_OPTIONS,
+  DEFAULT_SESSION_ID
 }

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -20,7 +20,7 @@ interface SessionData extends ExpressSessionData {
 
   encryptedSessionId: string;
 
-  /** Updates the `expires` property of the session. */
+  /** Updates the `expires` property of the session's cookie. */
   touch(): void;
 
   /**


### PR DESCRIPTION
Picking up where @simenb left off here: https://github.com/fastify/session/pull/101

- First, I rebased https://github.com/fastify/session/pull/101 on main. Needed to fix some Ava -> Tap stuff
- Next, I cleaned up the tests a little bit. There are some tests that modify a session or set expiration when that isn't the part of the test. It's best to keep tests more focused because otherwise bugs and slip through, as I'll talk about later.
- @SimenB had some [questions about the "multiple secrets" tests](https://github.com/fastify/session/pull/101#discussion_r909434094). The expiration was a red herring. The real issue was that sessionId/expiredSessionId wasn't in the session store, so the test always reset the sessionId. I made it cleaner.
- Finally, I found a bug in the original PR where saveUninitialized: true and maxAge wouldn't set a new cookie. It was because the hashing mechanism for dates converted all of them to the string "{}" by accident.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

#### Benchmarks

Running locally. Before:

```
$ node benchmark/bench.js
╔══════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ file         │      25 │  32.68 op/sec │ ±  7.20 % │                         ║
║ redis        │      25 │ 139.43 op/sec │ ± 18.75 % │ + 326.64 %              ║
╟──────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ memory       │      25 │ 760.16 op/sec │ ± 38.32 % │ + 2225.96 %             ║
╚══════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

✨  Done in 27.04s.
```

After:

```
$ node benchmark/bench.js
╔══════════════╤═════════╤═══════════════╤═══════════╤═════════════════════════╗
║ Slower tests │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ file         │      25 │  27.58 op/sec │ ± 15.34 % │                         ║
║ redis        │      25 │  80.42 op/sec │ ± 25.62 % │ + 191.56 %              ║
╟──────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ Fastest test │ Samples │        Result │ Tolerance │ Difference with slowest ║
╟──────────────┼─────────┼───────────────┼───────────┼─────────────────────────╢
║ memory       │      25 │ 781.85 op/sec │ ± 37.90 % │ + 2734.57 %             ║
╚══════════════╧═════════╧═══════════════╧═══════════╧═════════════════════════╝

✨  Done in 31.01s.
```