### PR TITLE
Bugfix: when there are secrets, we should re-sign with latest

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -30,8 +30,8 @@ module.exports = class Session {
     this.touch()
     if (!this.sessionId) {
       this.sessionId = this[generateId](this[requestKey])
-      this.encryptedSessionId = this[sign]()
     }
+    this.encryptedSessionId = this[sign]()
     this[originalHash] = this[hash]()
   }
 
@@ -69,7 +69,7 @@ module.exports = class Session {
 
   [addDataToSession] (prevSession) {
     for (const key in prevSession) {
-      if (key !== 'cookie') {
+      if (!['cookie', 'encryptedSessionId'].includes(key)) {
         this[key] = prevSession[key]
       }
     }

--- a/lib/session.js
+++ b/lib/session.js
@@ -11,7 +11,6 @@ const stringify = configureStringifier({ bigint: false })
 const maxAge = Symbol('maxAge')
 const secretKey = Symbol('secretKey')
 const sign = Symbol('sign')
-const addDataToSession = Symbol('addDataToSession')
 const generateId = Symbol('generateId')
 const requestKey = Symbol('request')
 const cookieOptsKey = Symbol('cookieOpts')
@@ -20,13 +19,18 @@ const hash = Symbol('hash')
 
 module.exports = class Session {
   constructor (request, idGenerator, cookieOpts, secret, prevSession = {}) {
-    this[generateId] = idGenerator
-    this.cookie = new Cookie(cookieOpts)
-    this[cookieOptsKey] = cookieOpts
-    this[maxAge] = cookieOpts.maxAge
-    this[secretKey] = secret
-    this[addDataToSession](prevSession)
+    // Copy over values from the previous session
+    for (const key in prevSession) {
+      this[key] = prevSession[key]
+    }
+
     this[requestKey] = request
+    this[generateId] = idGenerator
+    this[cookieOptsKey] = cookieOpts
+    this[secretKey] = secret
+
+    this.cookie = new Cookie(cookieOpts)
+    this[maxAge] = cookieOpts.maxAge
     this.touch()
     if (!this.sessionId) {
       this.sessionId = this[generateId](this[requestKey])
@@ -64,14 +68,6 @@ module.exports = class Session {
           }
         })
       })
-    }
-  }
-
-  [addDataToSession] (prevSession) {
-    for (const key in prevSession) {
-      if (!['cookie', 'encryptedSessionId'].includes(key)) {
-        this[key] = prevSession[key]
-      }
     }
   }
 


### PR DESCRIPTION
This PR is dependent on:
https://github.com/fastify/session/pull/120

Only the last commit is relevant for review for now.

Turns out, we were re-signing cookies with the new secret.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
