### PR TITLE
Move `expires` from session to session.cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Allows to destroy the session in the store. If you do not pass a callback, a Pro
 
 #### Session#touch()
 
-Updates the `expires` property of the session.
+Updates the `expires` property of the session's cookie.
 
 #### Session#regenerate(callback)
 

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -62,7 +62,7 @@ function decryptSession (sessionId, options, request, done) {
         newSession(secret, request, cookieOpts, idGenerator, done)
         return
       }
-      if (session?.expires && session.expires <= Date.now()) {
+      if (session?.cookie?.expires && session.cookie.expires <= Date.now()) {
         const restoredSession = Session.restore(
           request,
           idGenerator,

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -62,7 +62,7 @@ function decryptSession (sessionId, options, request, done) {
         newSession(secret, request, cookieOpts, idGenerator, done)
         return
       }
-      if (session?.cookie?.expires && session.cookie.expires <= Date.now()) {
+      if (session.cookie?.expires && session.cookie.expires <= Date.now()) {
         const restoredSession = Session.restore(
           request,
           idGenerator,

--- a/lib/session.js
+++ b/lib/session.js
@@ -69,7 +69,7 @@ module.exports = class Session {
 
   [addDataToSession] (prevSession) {
     for (const key in prevSession) {
-      if (!['expires', 'cookie'].includes(key)) {
+      if (!['cookie'].includes(key)) {
         this[key] = prevSession[key]
       }
     }

--- a/lib/session.js
+++ b/lib/session.js
@@ -69,7 +69,7 @@ module.exports = class Session {
 
   [addDataToSession] (prevSession) {
     for (const key in prevSession) {
-      if (!['cookie'].includes(key)) {
+      if (key !== 'cookie') {
         this[key] = prevSession[key]
       }
     }

--- a/lib/session.js
+++ b/lib/session.js
@@ -21,7 +21,6 @@ const hash = Symbol('hash')
 module.exports = class Session {
   constructor (request, idGenerator, cookieOpts, secret, prevSession = {}) {
     this[generateId] = idGenerator
-    this.expires = null
     this.cookie = new Cookie(cookieOpts)
     this[cookieOptsKey] = cookieOpts
     this[maxAge] = cookieOpts.maxAge
@@ -38,8 +37,7 @@ module.exports = class Session {
 
   touch () {
     if (this[maxAge]) {
-      this.expires = new Date(Date.now() + this[maxAge])
-      this.cookie.expires = this.expires
+      this.cookie.expires = new Date(Date.now() + this[maxAge])
     }
   }
 
@@ -177,7 +175,6 @@ module.exports = class Session {
     const restoredCookie = new Cookie(cookieOpts)
     restoredCookie.expires = new Date(prevSession.cookie.expires)
     restoredSession.cookie = restoredCookie
-    restoredSession.expires = restoredCookie.expires
     restoredSession[originalHash] = restoredSession[hash]()
     return restoredSession
   }

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -101,7 +101,9 @@ test('should set new session cookie if expired', async (t) => {
   const plugin = fastifyPlugin(async (fastify, opts) => {
     fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set(DEFAULT_SESSION_ID, {
-        expires: Date.now() - 1000
+        cookie: {
+          expires: Date.now() - 1000
+        }
       }, done)
     })
   })

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -20,7 +20,7 @@ interface SessionData extends ExpressSessionData {
 
   encryptedSessionId: string;
 
-  /** Updates the `expires` property of the session. */
+  /** Updates the `expires` property of the session's cookie. */
   touch(): void;
 
   /**


### PR DESCRIPTION
Moving the `expires` property out of session and into cookie for compatibility with express-session.

See discussion here:
https://github.com/fastify/session/pull/101#discussion_r909433854

Only look at most recent commit. This PR is dependent on test cleanup being merged first:
https://github.com/fastify/session/pull/117

No noticeable benchmark differences

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
