### PR TITLE
perf: improve idgenerator (about 25-30 % faster)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,11 @@ Setting this to `false` can save storage space and comply with the EU cookie law
 
 ##### idGenerator(request) (optional)
 
-Function used to generate new session IDs. Defaults to [`uid(24)`](https://github.com/crypto-utils/uid-safe).
+Function used to generate new session IDs..
 Custom implementation example:
 ```js
+const uid = require('uid-safe').sync
+
 idGenerator: (request) => {
      if (request.session.returningVisitor) return `returningVisitor-${uid(24)}`
      else return uid(24)

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Setting this to `false` can save storage space and comply with the EU cookie law
 
 ##### idGenerator(request) (optional)
 
-Function used to generate new session IDs..
+Function used to generate new session IDs.
 Custom implementation example:
 ```js
 const uid = require('uid-safe').sync

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const uid = require('uid-safe').sync
+const idGenerator = require('./idGenerator')
 const Store = require('./store')
 const Session = require('./session')
 const cookieSignature = require('cookie-signature')
@@ -180,10 +180,6 @@ function checkOptions (options) {
   if (Array.isArray(options.secret) && options.secret.length === 0) {
     return new Error('at least one secret is required')
   }
-}
-
-function idGenerator () {
-  return uid(24)
 }
 
 function ensureDefaults (options) {

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const idGenerator = require('./idGenerator')
+const idGenerator = require('./idGenerator')()
 const Store = require('./store')
 const Session = require('./session')
 const cookieSignature = require('cookie-signature')

--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -2,17 +2,38 @@
 
 const crypto = require('crypto')
 
-module.exports = idGenerator(32)
+const randomBytes = crypto.randomBytes
 
-function idGenerator (len) {
-  const fnBody = []
+const cacheSize = 24 << 7
+let pos = 0
+let cache = crypto.randomBytes(cacheSize)
 
-  fnBody.push('const randomInt = crypto.randomInt;')
-  fnBody.push('const base64url = \'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_\'.split(\'\');')
-  fnBody.push('return function () {')
-  const chars = []
-  for (let i = 0; i < ((len) | 0); ++i) chars.push('base64url[randomInt(0, 64)]')
-  fnBody.push('return ' + chars.join('+'))
-  fnBody.push('}')
-  return new Function('crypto', fnBody.join(''))(crypto) // eslint-disable-line no-new-func
+const EQUAL_END_REGEXP = /=/g
+const PLUS_GLOBAL_REGEXP = /\+/g
+const SLASH_GLOBAL_REGEXP = /\//g
+
+module.exports = function (useBase64Url = Buffer.isEncoding('base64url')) {
+  return useBase64Url
+    ? function idGenerator() {
+      if ((pos + 24) > cacheSize) {
+        cache = randomBytes(cacheSize)
+        pos = 0
+      }
+      const buf = Buffer.allocUnsafe(24)
+      cache.copy(buf, 0, pos, (pos += 24))
+      return buf.toString('base64url')
+    }
+    : function idGenerator() {
+      if ((pos + 24) > cacheSize) {
+        cache = randomBytes(cacheSize)
+        pos = 0
+      }
+      const buf = Buffer.allocUnsafe(24)
+      cache.copy(buf, 0, pos, (pos += 24))
+      return buf.toString('base64')
+        .replace(EQUAL_END_REGEXP, '')
+        .replace(PLUS_GLOBAL_REGEXP, '-')
+        .replace(SLASH_GLOBAL_REGEXP, '_')
+    }
 }
+

--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -1,0 +1,18 @@
+'use strict'
+
+const crypto = require('crypto')
+
+module.exports = idGenerator(32)
+
+function idGenerator (len) {
+  const fnBody = []
+
+  fnBody.push('const randomInt = crypto.randomInt;')
+  fnBody.push('const base64url = \'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_\'.split(\'\');')
+  fnBody.push('return function () {')
+  const chars = []
+  for (let i = 0; i < ((len) | 0); ++i) chars.push('base64url[randomInt(0, 64)]')
+  fnBody.push('return ' + chars.join('+'))
+  fnBody.push('}')
+  return new Function('crypto', fnBody.join(''))(crypto) // eslint-disable-line no-new-func
+}

--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -1,12 +1,10 @@
 'use strict'
 
-const crypto = require('crypto')
-
-const randomBytes = crypto.randomBytes
+const randomBytes = require('crypto').randomBytes
 
 const cacheSize = 24 << 7
 let pos = 0
-let cache = crypto.randomBytes(cacheSize)
+let cache = randomBytes(cacheSize)
 
 const EQUAL_END_REGEXP = /=/g
 const PLUS_GLOBAL_REGEXP = /\+/g

--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -14,7 +14,7 @@ const SLASH_GLOBAL_REGEXP = /\//g
 
 module.exports = function (useBase64Url = Buffer.isEncoding('base64url')) {
   return useBase64Url
-    ? function idGenerator() {
+    ? function idGenerator () {
       if ((pos + 24) > cacheSize) {
         cache = randomBytes(cacheSize)
         pos = 0
@@ -23,7 +23,7 @@ module.exports = function (useBase64Url = Buffer.isEncoding('base64url')) {
       cache.copy(buf, 0, pos, (pos += 24))
       return buf.toString('base64url')
     }
-    : function idGenerator() {
+    : function idGenerator () {
       if ((pos + 24) > cacheSize) {
         cache = randomBytes(cacheSize)
         pos = 0
@@ -36,4 +36,3 @@ module.exports = function (useBase64Url = Buffer.isEncoding('base64url')) {
         .replace(SLASH_GLOBAL_REGEXP, '_')
     }
 }
-

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   "dependencies": {
     "cookie-signature": "^1.1.0",
     "fastify-plugin": "^4.0.0",
-    "safe-stable-stringify": "^2.3.1",
-    "uid-safe": "^2.1.5"
+    "safe-stable-stringify": "^2.3.1"
   },
   "repository": {
     "type": "git",

--- a/test/idGenerator.test.js
+++ b/test/idGenerator.test.js
@@ -5,12 +5,29 @@ const idGenerator = require('../lib/idGenerator')
 
 const cacheSize = 1 << 7 + 1
 
-test('should have no collisions', async (t) => {
+if (Buffer.isEncoding('base64url')) {
+  test('should have no collisions, base64url', async (t) => {
+    const idGen = idGenerator(true)
+    t.plan(cacheSize)
+    const ids = new Set()
+
+    for (let i = 0; i < (cacheSize); ++i) {
+      const id = idGen()
+      if (ids.has(id)) {
+        t.fail('had a collision')
+      }
+      t.equal(id.length, 32)
+    }
+  })
+}
+
+test('should have no collisions, base64', async (t) => {
+  const idGen = idGenerator(false)
   t.plan(cacheSize)
   const ids = new Set()
 
   for (let i = 0; i < (cacheSize); ++i) {
-    const id = idGenerator()
+    const id = idGen()
     if (ids.has(id)) {
       t.fail('had a collision')
     }

--- a/test/idGenerator.test.js
+++ b/test/idGenerator.test.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const test = require('tap').test
+const idGenerator = require('../lib/idGenerator')
+
+const cacheSize = 1 << 7 + 1
+
+test('should have no collisions', async (t) => {
+  t.plan(cacheSize)
+  const ids = new Set()
+
+  for (let i = 0; i < (cacheSize); ++i) {
+    const id = idGenerator()
+    if (ids.has(id)) {
+      t.fail('had a collision')
+    }
+    t.equal(id.length, 32)
+  }
+})

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -120,7 +120,7 @@ declare namespace FastifySessionPlugin {
      */
     rolling?: boolean;
 
-    /** Function used to generate new session IDs. Defaults to uid(24). */
+    /** Function used to generate new session IDs. */
     idGenerator?(request?: Fastify.FastifyRequest): string;
   }
 


### PR DESCRIPTION
my server to run the benchmarkr

```
'use strict'

const Fastify = require('fastify')
const fastifySession = require('..')
const fastifyCookie = require('@fastify/cookie')

const fastify = Fastify()

fastify.register(fastifyCookie)
fastify.register(fastifySession, {
  secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
  cookie: { secure: false }
})

fastify.get('/', async (request, reply) => {
  reply
    .send(request.cookies.sessionId)
})

fastify.listen({ port: 3000 })
```


before:

```
autocannon  http://127.0.0.1:3000Running 10s test @ http://127.0.0.1:3000
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 1 ms │ 0.04 ms │ 0.34 ms │ 17 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬────────┬─────────┬─────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%    │ 97.5%   │ Avg     │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┼─────────┤
│ Req/Sec   │ 16463   │ 16463   │ 22975  │ 24671   │ 22565.1 │ 2038.33 │ 16455   │
├───────────┼─────────┼─────────┼────────┼─────────┼─────────┼─────────┼─────────┤
│ Bytes/Sec │ 4.01 MB │ 4.01 MB │ 5.6 MB │ 6.01 MB │ 5.5 MB  │ 497 kB  │ 4.01 MB │
└───────────┴─────────┴─────────┴────────┴─────────┴─────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

248k requests in 11.01s, 60.5 MB read
```
after:

```
autocannon  http://127.0.0.1:3000
Running 10s test @ http://127.0.0.1:3000
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 0 ms  │ 1 ms │ 0.04 ms │ 0.31 ms │ 19 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬─────────┬─────────┬─────────┬─────────┬──────────┬─────────┬─────────┐
│ Stat      │ 1%      │ 2.5%    │ 50%     │ 97.5%   │ Avg      │ Stdev   │ Min     │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Req/Sec   │ 18351   │ 18351   │ 26319   │ 27023   │ 25586.19 │ 2393.26 │ 18343   │
├───────────┼─────────┼─────────┼─────────┼─────────┼──────────┼─────────┼─────────┤
│ Bytes/Sec │ 4.47 MB │ 4.47 MB │ 6.41 MB │ 6.58 MB │ 6.23 MB  │ 583 kB  │ 4.47 MB │
└───────────┴─────────┴─────────┴─────────┴─────────┴──────────┴─────────┴─────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

281k requests in 11.01s, 68.6 MB read
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
