### PR TITLE
Revert "refactor store to es6 class"

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -1,25 +1,28 @@
 'use strict'
 
-const { EventEmitter } = require('events')
+const EventEmitter = require('events').EventEmitter
+const util = require('util')
 
-module.exports = class Store extends EventEmitter {
-  constructor (storeMap = new Map()) {
-    super()
-    this.store = storeMap
-  }
-
-  set (sessionId, session, callback) {
-    this.store.set(sessionId, session)
-    callback()
-  }
-
-  get (sessionId, callback) {
-    const session = this.store.get(sessionId)
-    callback(null, session)
-  }
-
-  destroy (sessionId, callback) {
-    this.store.delete(sessionId)
-    callback()
-  }
+function Store (storeMap = new Map()) {
+  this.store = storeMap
+  EventEmitter.call(this)
 }
+
+util.inherits(Store, EventEmitter)
+
+Store.prototype.set = function set (sessionId, session, callback) {
+  this.store.set(sessionId, session)
+  callback()
+}
+
+Store.prototype.get = function get (sessionId, callback) {
+  const session = this.store.get(sessionId)
+  callback(null, session)
+}
+
+Store.prototype.destroy = function destroy (sessionId, callback) {
+  this.store.delete(sessionId)
+  callback()
+}
+
+module.exports = Store


### PR DESCRIPTION
Reverts fastify/session#122

If it is a ES6 class it will have regressions, as some store implementations dont extend the store class but call the function instead. This results that the benchmarks failed

see https://github.com/valery-barysok/session-file-store/blob/b89a42b00f24e720bb9d07cc7ddf72ef6c43c7bc/lib/session-file-store.js#L26