### PR TITLE
dont use storeMap to check for store length

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -25,8 +25,4 @@ Store.prototype.destroy = function destroy (sessionId, callback) {
   callback()
 }
 
-Store.prototype.length = function length (callback) {
-  callback(null, this.store.size)
-}
-
 module.exports = Store

--- a/lib/store.js
+++ b/lib/store.js
@@ -20,6 +20,10 @@ module.exports = class Store extends EventEmitter {
 
   destroy (sessionId, callback) {
     this.store.delete(sessionId)
-    callback()
+    callback(null)
+  }
+
+  length (callback) {
+    callback(null, this.store.size)
   }
 }

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -22,16 +22,13 @@ test('should not set session cookie on post without params', async (t) => {
 })
 
 test('should save the session properly', async (t) => {
-  t.plan(6)
+  t.plan(5)
   const store = new Store()
+
   const fastify = await buildFastify(async (request, reply) => {
     request.session.test = true
 
     await request.session.save()
-    store.length((_err, length) => {
-      // Only one session
-      t.equal(length, 1)
-    })
 
     const sessionId = request.session.sessionId
 


### PR DESCRIPTION
This is a deviation of #137 
it makes it possible to also check file store and redis store when we agree on how to test them

new is length method of store, which is also provided by file store and redis store. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
