### PR TITLE
create a separate unit test file for memorystore

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -26,3 +26,6 @@ Store.prototype.destroy = function destroy (sessionId, callback) {
 }
 
 module.exports = Store
+module.exports.default = Store
+module.exports.Store = Store
+module.exports.MemoryStore = Store

--- a/test/memorystore.test.js
+++ b/test/memorystore.test.js
@@ -91,7 +91,7 @@ test('MemoryStore.destroy: should remove a sessionId / 2', t => {
   })
 })
 
-test('MemoryStore.destroy: should remove a sessionId / 2', t => {
+test('MemoryStore.destroy: should not remove stored sessions if invalidId is provided', t => {
   t.plan(3)
 
   const internalStore = new Map()

--- a/test/memorystore.test.js
+++ b/test/memorystore.test.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const test = require('tap').test
+const { MemoryStore } = require('../lib/store')
+const { EventEmitter } = require('stream')
+
+test('MemoryStore.constructor: created MemoryStore should be an EventEmitter', (t) => {
+  t.plan(2)
+
+  const store = new MemoryStore()
+
+  t.ok(store instanceof EventEmitter)
+  store.on('test', () => t.pass())
+  store.emit('test')
+})
+
+test('MemoryStore.constructor: should accept a Map as internal store', t => {
+  t.plan(1)
+
+  const internalStore = new Map()
+
+  const store = new MemoryStore(internalStore)
+
+  t.equal(store.store, internalStore)
+})
+
+test('MemoryStore.set: should successfully set a value to sessionId ', t => {
+  t.plan(4)
+
+  const internalStore = new Map()
+
+  t.equal(internalStore.size, 0)
+
+  const store = new MemoryStore(internalStore)
+  store.set('someId', { key: 'value' }, () => {
+    t.equal(internalStore.size, 1)
+    t.equal(internalStore.has('someId'), true)
+    t.strictSame(internalStore.get('someId'), { key: 'value' })
+  })
+})
+
+test('MemoryStore.get: should successfully get a value for a valid sessionId ', t => {
+  t.plan(1)
+
+  const internalStore = new Map()
+  internalStore.set('someId', { key: 'value' })
+
+  const store = new MemoryStore(internalStore)
+  store.get('someId', (_err, value) => {
+    t.strictSame(value, { key: 'value' })
+  })
+})
+
+test('MemoryStore.get: should return undefined for an invalid sessionId ', t => {
+  t.plan(1)
+
+  const internalStore = new Map()
+  internalStore.set('someId', { key: 'value' })
+
+  const store = new MemoryStore(internalStore)
+  store.get('invalidId', (_err, value) => {
+    t.strictSame(value, undefined)
+  })
+})
+
+test('MemoryStore.destroy: should remove a sessionId / 1', t => {
+  t.plan(2)
+
+  const internalStore = new Map()
+  internalStore.set('someId', { key: 'value' })
+  internalStore.set('anotherId', { key: 'value' })
+
+  const store = new MemoryStore(internalStore)
+  store.destroy('someId', () => {
+    t.equal(internalStore.size, 1)
+    t.ok(internalStore.has('anotherId'))
+  })
+})
+
+test('MemoryStore.destroy: should remove a sessionId / 2', t => {
+  t.plan(2)
+
+  const internalStore = new Map()
+  internalStore.set('someId', { key: 'value' })
+  internalStore.set('anotherId', { key: 'value' })
+
+  const store = new MemoryStore(internalStore)
+  store.destroy('anotherId', () => {
+    t.equal(internalStore.size, 1)
+    t.ok(internalStore.has('someId'))
+  })
+})
+
+test('MemoryStore.destroy: should remove a sessionId / 2', t => {
+  t.plan(3)
+
+  const internalStore = new Map()
+  internalStore.set('someId', { key: 'value' })
+  internalStore.set('anotherId', { key: 'value' })
+
+  const store = new MemoryStore(internalStore)
+  store.destroy('invalidId', () => {
+    t.equal(internalStore.size, 2)
+    t.ok(internalStore.has('someId'))
+    t.ok(internalStore.has('anotherId'))
+  })
+})

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -3,7 +3,6 @@
 const test = require('tap').test
 const fastifyPlugin = require('fastify-plugin')
 const { buildFastify, DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SECRET, DEFAULT_SESSION_ID } = require('./util')
-const { Store } = require('..')
 
 test('should decorate request with sessionStore', async (t) => {
   t.plan(2)
@@ -122,15 +121,6 @@ test('should set new session cookie if expired', async (t) => {
 
   t.equal(statusCode, 500)
   t.equal(cookie, undefined)
-})
-
-test('store should be an event emitter', t => {
-  t.plan(1)
-
-  const store = new Store()
-
-  store.on('test', () => t.pass())
-  store.emit('test')
 })
 
 class FailOnDestroyStore {


### PR DESCRIPTION
I want to restructure the unit tests. This one is the beginning.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
