### PR TITLE
use maxAge over expires

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -36,10 +36,10 @@ class Cookie {
 }
 
 function getExpires (cookieOpts) {
-  if (cookieOpts.expires) {
-    return cookieOpts.expires
-  } else if (cookieOpts.maxAge) {
+  if (cookieOpts.maxAge) {
     return new Date(Date.now() + cookieOpts.maxAge)
+  } else if (cookieOpts.expires) {
+    return cookieOpts.expires
   }
   return null
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -33,7 +33,6 @@ module.exports = class Session {
       }
     }
 
-    this.touch()
     if (!this.encryptedSessionId) {
       this.encryptedSessionId = cookieSigner.sign(this.sessionId)
     }

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -415,8 +415,7 @@ test('should set session secure cookie secureAuto x-forwarded-proto header', asy
 
 test('should use maxAge instead of expires in session if both are set in options.cookie', async (t) => {
   t.plan(3)
-  const expires = new Date()
-  expires.setTime(34214461000) // 1971-02-01T00:01:01.000Z
+  const expires = new Date(34214461000) // 1971-02-01T00:01:01.000Z
   const options = {
     secret: DEFAULT_SECRET,
     cookie: { maxAge: 1000, expires }


### PR DESCRIPTION
This PR makes maxAge being preferred over expires, like we documented it in the readme.md. The reason why it worked as documented, was that we do a .touch() when we instantiated a Session. So I removed the .touch() and fixed the getExpires method. 

@rclmenezes 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
