### PR TITLE
Make it possible to call save() in decryptSession

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -13,6 +13,7 @@ function fastifySession (fastify, options, next) {
 
   options = ensureDefaults(options)
 
+  const sessionStore = options.store
   const cookieSigner = options.signer
   const cookieName = options.cookieName
   const cookiePrefix = options.cookiePrefix
@@ -30,7 +31,7 @@ function fastifySession (fastify, options, next) {
     const cookie = { ...options.cookie, ...cookieOpts }
     decryptSession(sessionId, { ...options, cookie }, request, callback)
   })
-  fastify.decorateRequest('sessionStore', { getter: () => options.store })
+  fastify.decorateRequest('sessionStore', { getter: () => sessionStore })
   fastify.decorateRequest('session', null)
   fastify.addHook('onRequest', onRequest(options))
   fastify.addHook('onSend', onSend(options))
@@ -42,7 +43,13 @@ function fastifySession (fastify, options, next) {
 
     const unsignedCookie = cookieSigner.unsign(sessionId)
     if (unsignedCookie.valid === false) {
-      request.session = new Session(request, idGenerator, cookieOpts, cookieSigner)
+      request.session = new Session(
+        sessionStore,
+        request,
+        idGenerator,
+        cookieOpts,
+        cookieSigner
+      )
       done()
       return
     }
@@ -50,7 +57,13 @@ function fastifySession (fastify, options, next) {
     options.store.get(decryptedSessionId, (err, session) => {
       if (err) {
         if (err.code === 'ENOENT') {
-          request.session = new Session(request, idGenerator, cookieOpts, cookieSigner)
+          request.session = new Session(
+            sessionStore,
+            request,
+            idGenerator,
+            cookieOpts,
+            cookieSigner
+          )
           done()
         } else {
           done(err)
@@ -59,12 +72,19 @@ function fastifySession (fastify, options, next) {
       }
 
       if (!session) {
-        request.session = new Session(request, idGenerator, cookieOpts, cookieSigner)
+        request.session = new Session(
+          sessionStore,
+          request,
+          idGenerator,
+          cookieOpts,
+          cookieSigner
+        )
         done()
         return
       }
 
       const restoredSession = new Session(
+        sessionStore,
         request,
         idGenerator,
         cookieOpts,
@@ -118,7 +138,13 @@ function fastifySession (fastify, options, next) {
 
       const cookieSessionId = getCookieSessionId(request)
       if (!cookieSessionId) {
-        request.session = new Session(request, idGenerator, cookieOpts, cookieSigner)
+        request.session = new Session(
+          sessionStore,
+          request,
+          idGenerator,
+          cookieOpts,
+          cookieSigner
+        )
         done()
       } else {
         decryptSession(cookieSessionId, options, request, done)

--- a/lib/session.js
+++ b/lib/session.js
@@ -64,7 +64,7 @@ module.exports = class Session {
         this[cookieSignerKey]
       )
 
-      this[requestKey].sessionStore.set(session.sessionId, session, error => {
+      this[sessionStoreKey].set(session.sessionId, session, error => {
         this[requestKey].session = session
 
         callback(error)
@@ -79,7 +79,7 @@ module.exports = class Session {
           this[cookieSignerKey]
         )
 
-        this[requestKey].sessionStore.set(session.sessionId, session, error => {
+        this[sessionStoreKey].set(session.sessionId, session, error => {
           this[requestKey].session = session
 
           if (error) {
@@ -102,14 +102,14 @@ module.exports = class Session {
 
   destroy (callback) {
     if (callback) {
-      this[requestKey].sessionStore.destroy(this[sessionIdKey], error => {
+      this[sessionStoreKey].destroy(this[sessionIdKey], error => {
         this[requestKey].session = null
 
         callback(error)
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[requestKey].sessionStore.destroy(this[sessionIdKey], error => {
+        this[sessionStoreKey].destroy(this[sessionIdKey], error => {
           this[requestKey].session = null
 
           if (error) {
@@ -124,7 +124,7 @@ module.exports = class Session {
 
   reload (callback) {
     if (callback) {
-      this[requestKey].sessionStore.get(this[sessionIdKey], (error, session) => {
+      this[sessionStoreKey].get(this[sessionIdKey], (error, session) => {
         this[requestKey].session = new Session(this[requestKey],
           this[sessionStoreKey],
           this[generateId],
@@ -138,7 +138,7 @@ module.exports = class Session {
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[requestKey].sessionStore.get(this[sessionIdKey], (error, session) => {
+        this[sessionStoreKey].get(this[sessionIdKey], (error, session) => {
           this[requestKey].session = new Session(
             this[sessionStoreKey],
             this[requestKey],
@@ -161,12 +161,12 @@ module.exports = class Session {
 
   save (callback) {
     if (callback) {
-      this[requestKey].sessionStore.set(this[sessionIdKey], this, error => {
+      this[sessionStoreKey].set(this[sessionIdKey], this, error => {
         callback(error)
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[requestKey].sessionStore.set(this[sessionIdKey], this, error => {
+        this[sessionStoreKey].set(this[sessionIdKey], this, error => {
           if (error) {
             reject(error)
           } else {

--- a/lib/session.js
+++ b/lib/session.js
@@ -19,7 +19,15 @@ const sessionStoreKey = Symbol('sessionStore')
 const encryptedSessionIdKey = Symbol('encryptedSessionId')
 
 module.exports = class Session {
-  constructor (sessionStore, request, idGenerator, cookieOpts, cookieSigner, prevSession, sessionId = idGenerator(request)) {
+  constructor (
+    sessionStore,
+    request,
+    idGenerator,
+    cookieOpts,
+    cookieSigner,
+    prevSession,
+    sessionId = idGenerator(request)
+  ) {
     this[sessionStoreKey] = sessionStore
     this[generateId] = idGenerator
     this[cookieOptsKey] = cookieOpts

--- a/lib/session.js
+++ b/lib/session.js
@@ -15,10 +15,12 @@ const cookieOptsKey = Symbol('cookieOpts')
 const originalHash = Symbol('originalHash')
 const hash = Symbol('hash')
 const sessionIdKey = Symbol('sessionId')
+const sessionStoreKey = Symbol('sessionStore')
 const encryptedSessionIdKey = Symbol('encryptedSessionId')
 
 module.exports = class Session {
-  constructor (request, idGenerator, cookieOpts, cookieSigner, prevSession, sessionId = idGenerator(request)) {
+  constructor (sessionStore, request, idGenerator, cookieOpts, cookieSigner, prevSession, sessionId = idGenerator(request)) {
+    this[sessionStoreKey] = sessionStore
     this[generateId] = idGenerator
     this[cookieOptsKey] = cookieOpts
     this[maxAge] = cookieOpts.maxAge
@@ -35,7 +37,11 @@ module.exports = class Session {
     if (prevSession) {
       // Copy over values from the previous session
       for (const key in prevSession) {
-        (key !== 'cookie') && (this[key] = prevSession[key])
+        (
+          key !== 'cookie' &&
+          key !== 'sessionId' &&
+          key !== 'encryptedSessionId'
+        ) && (this[key] = prevSession[key])
       }
     }
 
@@ -50,7 +56,13 @@ module.exports = class Session {
 
   regenerate (callback) {
     if (callback) {
-      const session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[cookieSignerKey])
+      const session = new Session(
+        this[sessionStoreKey],
+        this[requestKey],
+        this[generateId],
+        this[cookieOptsKey],
+        this[cookieSignerKey]
+      )
 
       this[requestKey].sessionStore.set(session.sessionId, session, error => {
         this[requestKey].session = session
@@ -59,7 +71,13 @@ module.exports = class Session {
       })
     } else {
       return new Promise((resolve, reject) => {
-        const session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[cookieSignerKey])
+        const session = new Session(
+          this[sessionStoreKey],
+          this[requestKey],
+          this[generateId],
+          this[cookieOptsKey],
+          this[cookieSignerKey]
+        )
 
         this[requestKey].sessionStore.set(session.sessionId, session, error => {
           this[requestKey].session = session
@@ -107,14 +125,29 @@ module.exports = class Session {
   reload (callback) {
     if (callback) {
       this[requestKey].sessionStore.get(this[sessionIdKey], (error, session) => {
-        this[requestKey].session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[cookieSignerKey], session, this[sessionIdKey])
+        this[requestKey].session = new Session(this[requestKey],
+          this[sessionStoreKey],
+          this[generateId],
+          this[cookieOptsKey],
+          this[cookieSignerKey],
+          session,
+          this[sessionIdKey]
+        )
 
         callback(error)
       })
     } else {
       return new Promise((resolve, reject) => {
         this[requestKey].sessionStore.get(this[sessionIdKey], (error, session) => {
-          this[requestKey].session = new Session(this[requestKey], this[generateId], this[cookieOptsKey], this[cookieSignerKey], session, this[sessionIdKey])
+          this[requestKey].session = new Session(
+            this[sessionStoreKey],
+            this[requestKey],
+            this[generateId],
+            this[cookieOptsKey],
+            this[cookieSignerKey],
+            session,
+            this[sessionIdKey]
+          )
 
           if (error) {
             reject(error)

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -215,7 +215,7 @@ test('should decorate the server with decryptSession', async t => {
 })
 
 test('should decryptSession with custom request object', async (t) => {
-  t.plan(4)
+  t.plan(5)
   const fastify = Fastify()
 
   const options = {
@@ -245,6 +245,10 @@ test('should decryptSession with custom request object', async (t) => {
   const { sessionId } = fastify.parseCookie(DEFAULT_COOKIE)
   const requestObj = {}
   fastify.decryptSession(sessionId, requestObj, () => {
+    // it should be possible to save the session
+    requestObj.session.save(err => {
+      t.error(err)
+    })
     t.equal(requestObj.session.cookie.maxAge, null)
     t.equal(requestObj.session.testData, 'this is a test')
     t.equal(requestObj.session.sessionId, DEFAULT_SESSION_ID)


### PR DESCRIPTION
It seems that in some cases the request is not decorated with the sessionStore. Instead we keep now a reference to the sessionStore directly and access the sessionStore instead of always accessing it through the request-Object. 
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
