### PR TITLE
Remove deprecation notice for fastify-Instance decryptSession

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -21,7 +21,6 @@ function fastifySession (fastify, options, next) {
   const cookiePrefixLength = hasCookiePrefix && cookiePrefix.length
 
   // Decorator function takes cookieOpts so we can customize on per-session basis.
-  // Note: method is deprecated, avoid using unless you need this functionality.
   fastify.decorate('decryptSession', (sessionId, request, cookieOpts, callback) => {
     if (typeof cookieOpts === 'function') {
       callback = cookieOpts


### PR DESCRIPTION
Related to issue #163 .

The deprecation of `decryptSession` is reversed to support scenarios where node services can be hybrid and can potentially have the need to share the sessions between Fastify and other libraries like socket.io.

#### Checklist

- [X ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [X ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
