### PR TITLE
security: verify path of cookie/session

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -131,7 +131,7 @@ function fastifySession (fastify, options, next) {
       request.session = {}
 
       const url = request.raw.url
-      if (url.indexOf(cookieOpts.path || '/') !== 0) {
+      if (verifyPath(url, cookieOpts.path || '/') === false) {
         done()
         return
       }
@@ -228,6 +228,25 @@ function fastifySession (fastify, options, next) {
 
   function option (options, key, def) {
     return options[key] === undefined ? def : options[key]
+  }
+
+  function verifyPath (path, cookiePath) {
+    if (path === cookiePath) {
+      return true
+    }
+    const pathLength = path.length
+    const cookiePathLength = cookiePath.length
+
+    if (pathLength <= cookiePathLength) {
+      return false
+    } else if (path.startsWith(cookiePath)) {
+      if (path[cookiePathLength] === '/') {
+        return true
+      } else if (cookiePath[cookiePathLength - 1] === '/') {
+        return true
+      }
+    }
+    return false
   }
 }
 

--- a/test/verifyPath.test.js
+++ b/test/verifyPath.test.js
@@ -221,7 +221,7 @@ test('should handle path properly /5', async (t) => {
   t.equal(response2.statusCode, 200)
 })
 
-test('should handle path properly /5', async (t) => {
+test('should handle path properly /6', async (t) => {
   t.plan(3)
   const fastify = Fastify()
 
@@ -257,7 +257,7 @@ test('should handle path properly /5', async (t) => {
   t.equal(response2.statusCode, 200)
 })
 
-test('should handle path properly /6', async (t) => {
+test('should handle path properly /7', async (t) => {
   t.plan(3)
   const fastify = Fastify()
 

--- a/test/verifyPath.test.js
+++ b/test/verifyPath.test.js
@@ -1,0 +1,294 @@
+'use strict'
+
+const test = require('tap').test
+const Fastify = require('fastify')
+const fastifyCookie = require('@fastify/cookie')
+const fastifySession = require('..')
+const { DEFAULT_SECRET } = require('./util')
+
+test('should handle path properly /1', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.get('/', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/check', (request, reply) => {
+    t.equal(request.session.foo, 'bar')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /2', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/check', (request, reply) => {
+    t.equal(request.session.foo, 'bar')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /2', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/check/page1', (request, reply) => {
+    t.equal(request.session.foo, 'bar')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check/page1',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /3', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/check_page1', (request, reply) => {
+    t.same(request.session.foo, null)
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check_page1',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /4', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/chick/page1', (request, reply) => {
+    t.same(request.session.foo, null)
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/chick/page1',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /5', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/chck', (request, reply) => {
+    t.same(request.session.foo, null)
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/chck',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /5', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check/index', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/check/page1', (request, reply) => {
+    t.same(request.session.foo, 'bar')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check/index',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check/page1',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should handle path properly /6', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false, path: '/check/' }
+  }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.post('/check/index', (request, reply) => {
+    request.session.foo = 'bar'
+    reply.send(200)
+  })
+  fastify.get('/check/page1', (request, reply) => {
+    t.same(request.session.foo, 'bar')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/check/index',
+    method: 'POST'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check/page1',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})

--- a/test/verifyPath.test.js
+++ b/test/verifyPath.test.js
@@ -24,8 +24,6 @@ test('should handle path properly /1', async (t) => {
     t.equal(request.session.foo, 'bar')
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/'
@@ -59,8 +57,6 @@ test('should handle path properly /2', async (t) => {
     t.equal(request.session.foo, 'bar')
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check',
@@ -95,8 +91,6 @@ test('should handle path properly /2', async (t) => {
     t.equal(request.session.foo, 'bar')
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check',
@@ -131,8 +125,6 @@ test('should handle path properly /3', async (t) => {
     t.same(request.session.foo, null)
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check',
@@ -167,8 +159,6 @@ test('should handle path properly /4', async (t) => {
     t.same(request.session.foo, null)
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check',
@@ -203,8 +193,6 @@ test('should handle path properly /5', async (t) => {
     t.same(request.session.foo, null)
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check',
@@ -239,8 +227,6 @@ test('should handle path properly /6', async (t) => {
     t.same(request.session.foo, 'bar')
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check/index',
@@ -275,8 +261,6 @@ test('should handle path properly /7', async (t) => {
     t.same(request.session.foo, 'bar')
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check/index',
@@ -315,8 +299,6 @@ test('should handle path properly /8', async (t) => {
     t.same(request.session.foo, null)
     reply.send(200)
   })
-  await fastify.listen({ port: 0 })
-  t.teardown(() => { fastify.close() })
 
   const response1 = await fastify.inject({
     url: '/check/index',


### PR DESCRIPTION
This PR ensures that we respect the path of the session. So we dont load the session if the cookie is sent to a different path. 

when is it relevant?

If I set the cookie to the path `/admin` and send it to `/admin-ui`, it was previously loading the session. 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
