### PR TITLE
Dont load sessions from insecure connections from secure cookies and vice versa

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -29,7 +29,13 @@ function fastifySession (fastify, options, next) {
     }
 
     const cookie = { ...options.cookie, ...cookieOpts }
-    decryptSession(sessionId, { ...options, cookie }, request, true, callback)
+    decryptSession({
+      sessionId,
+      options: { ...options, cookie },
+      request,
+      custom: true,
+      callback
+    })
   })
   fastify.decorateRequest('sessionStore', { getter: () => sessionStore })
   fastify.decorateRequest('session', null)
@@ -37,7 +43,14 @@ function fastifySession (fastify, options, next) {
   fastify.addHook('onSend', onSend(options))
   next()
 
-  function decryptSession (sessionId, options, request, custom, done) {
+  function decryptSession (opts) {
+    const {
+      sessionId,
+      options,
+      request,
+      custom,
+      callback: done
+    } = opts
     const cookieOpts = options.cookie
     const idGenerator = options.idGenerator
 
@@ -152,7 +165,13 @@ function fastifySession (fastify, options, next) {
         )
         done()
       } else {
-        decryptSession(cookieSessionId, options, request, false, done)
+        decryptSession({
+          sessionId: cookieSessionId,
+          options,
+          request,
+          custom: false,
+          callback: done
+        })
       }
     }
   }

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -29,7 +29,7 @@ function fastifySession (fastify, options, next) {
     }
 
     const cookie = { ...options.cookie, ...cookieOpts }
-    decryptSession(sessionId, { ...options, cookie }, request, callback)
+    decryptSession(sessionId, { ...options, cookie }, request, true, callback)
   })
   fastify.decorateRequest('sessionStore', { getter: () => sessionStore })
   fastify.decorateRequest('session', null)
@@ -37,7 +37,7 @@ function fastifySession (fastify, options, next) {
   fastify.addHook('onSend', onSend(options))
   next()
 
-  function decryptSession (sessionId, options, request, done) {
+  function decryptSession (sessionId, options, request, custom, done) {
     const cookieOpts = options.cookie
     const idGenerator = options.idGenerator
 
@@ -105,7 +105,12 @@ function fastifySession (fastify, options, next) {
         return
       }
 
-      request.session = restoredSession
+      const secureConnectionCookieMismatch = custom !== true &&
+        (typeof cookieOpts.secure === 'boolean'
+          ? cookieOpts.secure !== isConnectionSecure(request)
+          : session.cookie.secure !== isConnectionSecure(request))
+
+      request.session = secureConnectionCookieMismatch ? {} : restoredSession
       done()
     })
   }
@@ -147,7 +152,7 @@ function fastifySession (fastify, options, next) {
         )
         done()
       } else {
-        decryptSession(cookieSessionId, options, request, done)
+        decryptSession(cookieSessionId, options, request, false, done)
       }
     }
   }
@@ -166,8 +171,11 @@ function fastifySession (fastify, options, next) {
 
       const cookieSessionId = getCookieSessionId(request)
       const saveSession = shouldSaveSession(request, cookieSessionId, saveUninitializedSession, rollingSessions)
-      const isInsecureConnection = cookieOpts.secure === true && isConnectionSecure(request) === false
-      if (!saveSession || isInsecureConnection) {
+      const secureConnectionCookieMismatch = typeof cookieOpts.secure === 'boolean'
+        ? cookieOpts.secure !== isConnectionSecure(request)
+        : session.cookie.secure !== isConnectionSecure(request)
+
+      if (!saveSession || secureConnectionCookieMismatch) {
         // if a session cookie is set, but has a different ID, clear it
         if (cookieSessionId && cookieSessionId !== session.encryptedSessionId) {
           reply.clearCookie(cookieName)


### PR DESCRIPTION
I dont know how to explain this properly. I think this is not a real security issue, but should be anyway handled correctly:

If you send a cookie with secure flag, through an insecure http connection, it would  result in loading the session. I would not expect that. 

We are signing and unsigning cookies. So the content of a cookie is practically safe. So that is the reason why it is not a real security issue. 

But it is possible to send a secure cookie to an unsecure connection. So it loads the session and in the handler we can access the session, even though the connection was not secure anyway. So in the handler you can modify the session and call .save or because you loaded the data you process it anyway.

Maybe it is a security breach because you are a bank or whatever and need even to handle that case very strict because of some security rules/laws. 

Maybe it is a brainfart from my side and I make it more complicated and didnt understand how cookies should be treaded.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
