### PR TITLE
fix: set domain when clearing cookie

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -170,7 +170,7 @@ function fastifySession (fastify, options, next) {
       if (!saveSession || isInsecureConnection) {
         // if a session cookie is set, but has a different ID, clear it
         if (cookieSessionId && cookieSessionId !== session.encryptedSessionId) {
-          reply.clearCookie(cookieName)
+          reply.clearCookie(cookieName, { domain: cookieOpts.domain })
         }
         done()
         return

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -723,6 +723,22 @@ test("clears cookie if not backed by a session, and there's nothing to save", as
   t.plan(2)
   const fastify = await buildFastify((request, reply) => {
     reply.send(200)
+  }, DEFAULT_OPTIONS)
+  t.teardown(() => fastify.close())
+
+  const response = await fastify.inject({
+    url: '/',
+    headers: { cookie: DEFAULT_COOKIE_VALUE }
+  })
+
+  t.equal(response.statusCode, 200)
+  t.equal(response.headers['set-cookie'], 'sessionId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+})
+
+test("clearing cookie sets the domain if it's specified in the cookie options", async t => {
+  t.plan(2)
+  const fastify = await buildFastify((request, reply) => {
+    reply.send(200)
   }, {
     ...DEFAULT_OPTIONS,
     cookie: { domain: 'domain.test' }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -723,7 +723,10 @@ test("clears cookie if not backed by a session, and there's nothing to save", as
   t.plan(2)
   const fastify = await buildFastify((request, reply) => {
     reply.send(200)
-  }, DEFAULT_OPTIONS)
+  }, {
+    ...DEFAULT_OPTIONS,
+    cookie: { domain: 'domain.test' }
+  })
   t.teardown(() => fastify.close())
 
   const response = await fastify.inject({
@@ -732,7 +735,7 @@ test("clears cookie if not backed by a session, and there's nothing to save", as
   })
 
   t.equal(response.statusCode, 200)
-  t.equal(response.headers['set-cookie'], 'sessionId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
+  t.equal(response.headers['set-cookie'], 'sessionId=; Domain=domain.test; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT')
 })
 
 test('does not clear cookie if no session cookie in request', async t => {


### PR DESCRIPTION
This PR fixes the issue #173. If user specifies `domain` in a cookie, but runs the server behind a subdomain, then a duplicate empty cookie is created at the specified condition and it will always be used for the following HTTP requests as a SID cookie, breaking the session mechanism.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
