### PR TITLE
Allow null Session in SessionCallback when there is an error.

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -26,7 +26,12 @@ type FastifySession = FastifyPluginCallback<fastifySession.FastifySessionOptions
 }
 
 type Callback = (err?: Error) => void;
-type CallbackSession = (err: Error | null, result: Fastify.Session) => void;
+//type CallbackSession = (err: Error | null, result: Fastify.Session) => void;
+
+interface CallbackSession {
+  (err: null, result: Fastify.Session): void
+  (err: Error, result: null): void
+}
 
 interface SessionData extends ExpressSessionData {
   sessionId: string;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -88,8 +88,10 @@ app.route({
     request.sessionStore.set('session-set-test', request.session, () => {});
     request.sessionStore.get('', (err, session) => {
       expectType<Error | null>(err);
-      expectType<Session>(session);
-      expectType<{ id: number } | undefined>(session.user);
+      expectType<Session | null>(session);
+      if (session) {
+        expectType<{ id: number } | undefined>(session.user);
+      }
     });
     expectType<void>(request.session.set('foo', 'bar'));
     expectType<string>(request.session.get('foo'));


### PR DESCRIPTION
It looks like the existing code support an error being thrown  on `store.get`, however, the type definition `SessionCallback` for the callback function on `store.get` requires a `Session` type variable for the session argument. This change would not cause the type check to fail when you call the `store.get` callback function like so:

```
callback(new Error("Some error"), null)
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
