### PR TITLE
types: fix Session interface reference

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -11,7 +11,7 @@ declare module 'fastify' {
 
   interface FastifyRequest {
     /** Allows to access or modify the session data. */
-    session: Fastify.Session;
+    session: Session;
 
     /** A session store. */
     sessionStore: Readonly<fastifySession.SessionStore>;


### PR DESCRIPTION
now Session actually resolves to the session interface defined in the same files instead of being an unresolved any. goal of this change is to fix #181 

before:
<img width="659" alt="Screenshot 2022-12-22 at 11 53 10 AM" src="https://user-images.githubusercontent.com/691152/209216577-d7f8eae9-b3b9-4a1b-939c-4182361129e2.png">

after:
<img width="486" alt="Screenshot 2022-12-22 at 11 53 22 AM" src="https://user-images.githubusercontent.com/691152/209216599-934c1987-5933-4296-a2e1-dda8a63debd7.png">



<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This doesn't require a new test/benchmark or doc change to the best of my knowledge.