### PR TITLE
feat: add ignoreFields option to regenerate method

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Allows to destroy the session in the store. If you do not pass a callback, a Pro
 
 Updates the `expires` property of the session's cookie.
 
-#### Session#regenerate(callback)
+#### Session#regenerate([ignoreFields, ]callback)
 
 Regenerates the session by generating a new `sessionId` and persist it to the store. If you do not pass a callback, a Promise will be returned.
 ```js
@@ -132,6 +132,8 @@ fastify.get('/regenerate', (request, reply, done) => {
   });
 });
 ```
+
+You can pass an array of fields that should be kept when the session is regenerated
 
 #### Session#reload(callback)
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -60,16 +60,26 @@ module.exports = class Session {
     }
   }
 
-  regenerate (callback) {
-    if (callback) {
-      const session = new Session(
-        this[sessionStoreKey],
-        this[requestKey],
-        this[generateId],
-        this[cookieOptsKey],
-        this[cookieSignerKey]
-      )
+  regenerate (keys, callback) {
+    if (typeof keys === 'function') {
+      callback = keys
+      keys = undefined
+    }
+    const session = new Session(
+      this[sessionStoreKey],
+      this[requestKey],
+      this[generateId],
+      this[cookieOptsKey],
+      this[cookieSignerKey]
+    )
 
+    if (Array.isArray(keys)) {
+      for (const key of keys) {
+        session.set(key, this[key])
+      }
+    }
+
+    if (callback) {
       this[sessionStoreKey].set(session.sessionId, session, error => {
         this[requestKey].session = session
 
@@ -77,14 +87,6 @@ module.exports = class Session {
       })
     } else {
       return new Promise((resolve, reject) => {
-        const session = new Session(
-          this[sessionStoreKey],
-          this[requestKey],
-          this[generateId],
-          this[cookieOptsKey],
-          this[cookieSignerKey]
-        )
-
         this[sessionStoreKey].set(session.sessionId, session, error => {
           this[requestKey].session = session
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -201,6 +201,89 @@ test('should generate new sessionId', async (t) => {
   t.equal(response2.statusCode, 200)
 })
 
+test('should generate new sessionId keeping ignoreFields', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false }
+  }
+  let oldSessionId
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.get('/', (request, reply) => {
+    oldSessionId = request.session.sessionId
+    request.session.set('message', 'hello world')
+    request.session.regenerate(['message'], error => {
+      if (error) {
+        reply.status(500).send('Error ' + error)
+      } else {
+        reply.send(200)
+      }
+    })
+  })
+  fastify.get('/check', (request, reply) => {
+    t.not(request.session.sessionId, oldSessionId)
+    t.equal(request.session.get('message'), 'hello world')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
+test('should generate new sessionId keeping ignoreFields (async)', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false }
+  }
+  let oldSessionId
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.get('/', async (request, reply) => {
+    oldSessionId = request.session.sessionId
+    request.session.set('message', 'hello world')
+    await request.session.regenerate(['message'])
+    reply.send(200)
+  })
+  fastify.get('/check', (request, reply) => {
+    t.not(request.session.sessionId, oldSessionId)
+    t.equal(request.session.get('message'), 'hello world')
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response1 = await fastify.inject({
+    url: '/'
+  })
+
+  t.equal(response1.statusCode, 200)
+
+  const response2 = await fastify.inject({
+    url: '/check',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+
+  t.equal(response2.statusCode, 200)
+})
+
 test('should decorate the server with decryptSession', async t => {
   t.plan(2)
   const fastify = Fastify()

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -38,9 +38,13 @@ interface SessionData extends ExpressSessionData {
 
   /**
    * Regenerates the session by generating a new `sessionId`.
+   *
+   * ignoreFields specifies which fields should be kept in the new session object.
    */
   regenerate(callback: Callback): void;
+  regenerate(ignoreFields: string[], callback: Callback): void;
   regenerate(): Promise<void>;
+  regenerate(ignoreFields: string[]): Promise<void>;
 
   /** Allows to destroy the session in the store. */
   destroy(callback: Callback): void;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -98,10 +98,12 @@ app.route({
     expectType<void>(request.session.reload(() => {}));
     expectType<void>(request.session.destroy(() => {}));
     expectType<void>(request.session.regenerate(() => {}));
+    expectType<void>(request.session.regenerate(['foo'], () => {}));
     expectType<void>(request.session.save(() => {}));
     expectType<Promise<void>>(request.session.reload());
     expectType<Promise<void>>(request.session.destroy());
     expectType<Promise<void>>(request.session.regenerate());
+    expectType<Promise<void>>(request.session.regenerate(['foo']));
     expectType<Promise<void>>(request.session.save());
   }
 });


### PR DESCRIPTION
You can pass an array of fields that should be kept when the session is regenerated