### PR TITLE
fix: express session type compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,27 +178,6 @@ declare module "fastify" {
 }
 ```
 
-While this plugin can be used with express-session compatible stores, the type definitions of some stores might be tied to express-session, which means that casting to `any` might be required. For example:
-
-```ts
-import fastifySession from '@fastify/session'
-import fastify from 'fastify'
-import Redis from 'ioredis'
-import connectRedis from 'connect-redis'
-
-const RedisStore = connectRedis(fastifySession as any)
-const redisClient = new Redis(redisConfig)
-
-const server = fastify()
-server.register(fastifySession, {
-  store: new RedisStore({
-    client: redisClient,
-    // ... other options
-  }) as any,
-  // ... other options
-})
-```
-
 ## License
 
 [MIT](./LICENSE)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@fastify/cookie": "^8.0.0",
     "@fastify/pre-commit": "^2.0.2",
     "@types/node": "^18.0.0",
+    "connect-mongo": "^5.0.0",
     "connect-redis": "^7.0.0",
     "cronometro": "^1.1.0",
     "fastify": "^4.3.0",

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -11,13 +11,13 @@ declare module 'fastify' {
 
   interface FastifyRequest {
     /** Allows to access or modify the session data. */
-    session: Session;
+    session: FastifySessionObject;
 
     /** A session store. */
     sessionStore: Readonly<fastifySession.SessionStore>;
   }
-
-  interface Session extends SessionData { }
+  
+  interface Session extends ExpressSessionData { }
 }
 
 type FastifySession = FastifyPluginCallback<fastifySession.FastifySessionOptions> & {
@@ -25,10 +25,10 @@ type FastifySession = FastifyPluginCallback<fastifySession.FastifySessionOptions
   MemoryStore: fastifySession.MemoryStore,
 }
 
-type Callback = (err?: Error) => void;
-type CallbackSession = (err: Error | null, result: Fastify.Session) => void;
+type Callback = (err?: any) => void;
+type CallbackSession = (err: any, result?: Fastify.Session | null) => void;
 
-interface SessionData extends ExpressSessionData {
+interface FastifySessionObject extends Fastify.Session {
   sessionId: string;
 
   encryptedSessionId: string;
@@ -65,7 +65,18 @@ interface SessionData extends ExpressSessionData {
 }
 
 interface ExpressSessionData {
-  cookie: fastifySession.CookieOptions;
+  /** The cookie properties as defined by express-session */
+  cookie: {
+    originalMaxAge: number | null;
+    maxAge?: number;
+    signed?: boolean;
+    expires?: Date | null;
+    httpOnly?: boolean;
+    path?: string;
+    domain?: string;
+    secure?: boolean | 'auto';
+    sameSite?: boolean | 'lax' | 'strict' | 'none';
+  }
 }
 
 interface UnsignResult {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

This PR was motivated by the current need to assert that the Store types are `any` due to the incompatibility of @fastify/session's types with express-session's. e.g.

```ts
server.register(fastifySession, {
  store: new RedisStore({
    client: redisClient,
  }) as any,
```

I tried to keep the changes to a minimum, but it was necessary to alter the callbacks types and to change precisely what was in the various Session types.

The callback needed updating because express-session's callbacks all define their errors as `any` and because we can't guarantee that a `session` is passed to the callback.

The Session types needed updating because the stores are only compatible with express-session's `SessionData` rather than the full set of properties that a fastify session object has.

I wasn't able to run the benchmarks locally, this PR only modifies types, so I hope that's okay.