### PR TITLE
Allow null Session in CallbackSession when there is an error

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -26,12 +26,6 @@ type FastifySession = FastifyPluginCallback<fastifySession.FastifySessionOptions
 }
 
 type Callback = (err?: Error) => void;
-//type CallbackSession = (err: Error | null, result: Fastify.Session) => void;
-
-interface CallbackSession {
-  (err: null, result: Fastify.Session): void
-  (err: Error): void
-}
 
 interface SessionData extends ExpressSessionData {
   sessionId: string;
@@ -85,6 +79,8 @@ interface Signer {
 }
 
 declare namespace fastifySession {
+  export type CallbackSession = (err: null | Error, result: undefined | Fastify.Session) => void
+
   export interface SessionStore {
     set(
       sessionId: string,

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -26,7 +26,12 @@ type FastifySession = FastifyPluginCallback<fastifySession.FastifySessionOptions
 }
 
 type Callback = (err?: Error) => void;
-type CallbackSession = (err: Error | null, result: Fastify.Session) => void;
+//type CallbackSession = (err: Error | null, result: Fastify.Session) => void;
+
+interface CallbackSession {
+  (err: null, result: Fastify.Session): void
+  (err: Error, result: null): void
+}
 
 interface SessionData extends ExpressSessionData {
   sessionId: string;

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -30,7 +30,7 @@ type Callback = (err?: Error) => void;
 
 interface CallbackSession {
   (err: null, result: Fastify.Session): void
-  (err: Error, result: null): void
+  (err: Error): void
 }
 
 interface SessionData extends ExpressSessionData {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -79,7 +79,7 @@ interface Signer {
 }
 
 declare namespace fastifySession {
-  export type CallbackSession = (err: null | Error, result: undefined | Fastify.Session) => void
+  export type CallbackSession = ((err: Error) => void) | ((err: null, result: Fastify.Session) => void)
 
   export interface SessionStore {
     set(

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -79,7 +79,10 @@ interface Signer {
 }
 
 declare namespace fastifySession {
-  export type CallbackSession = ((err: Error) => void) | ((err: null, result: Fastify.Session) => void)
+  export type CallbackSession = {
+    (err: Error, result?: undefined): void;
+    (err: null, result: Fastify.Session): void;
+  }
 
   export interface SessionStore {
     set(

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -86,12 +86,9 @@ app.route({
     expectError(request.session.doesNotExist());
     expectType<{ id: number } | undefined>(request.session.user);
     request.sessionStore.set('session-set-test', request.session, () => {});
-    request.sessionStore.get('', (err, session) => {
+    request.sessionStore.get('', (err, result) => {
       expectType<Error | null>(err);
-      expectType<Session | null>(session);
-      if (session) {
-        expectType<{ id: number } | undefined>(session.user);
-      }
+      expectType<Session | undefined>(result);
     });
     expectType<void>(request.session.set('foo', 'bar'));
     expectType<string>(request.session.get('foo'));

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -86,9 +86,12 @@ app.route({
     expectError(request.session.doesNotExist());
     expectType<{ id: number } | undefined>(request.session.user);
     request.sessionStore.set('session-set-test', request.session, () => {});
-    request.sessionStore.get('', (err, result) => {
+    request.sessionStore.get('', (err, session) => {
       expectType<Error | null>(err);
-      expectType<Session | undefined>(result);
+      expectType<Session | undefined>(session);
+      if (session) {
+        expectType<{ id: number } | undefined>(session.user);
+      }
     });
     expectType<void>(request.session.set('foo', 'bar'));
     expectType<string>(request.session.get('foo'));

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -88,8 +88,10 @@ app.route({
     request.sessionStore.set('session-set-test', request.session, () => {});
     request.sessionStore.get('', (err, session) => {
       expectType<Error | null>(err);
-      expectType<Session>(session);
-      expectType<{ id: number } | undefined>(session.user);
+      expectType<Session | null>(session);
+      if (session) {
+        expectType<{ id: number } | undefined>(session.user);
+      }
     });
     expectType<void>(request.session.set('foo', 'bar'));
     expectType<string>(request.session.get('foo'));


### PR DESCRIPTION
This is a follow-up of #180.

The change allows to call the `SessionStore.get` `callback` parameter with
```
callback(new Error());
```
instead of the current unnecessary
```
callback(new Error(), null)
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
