### PR TITLE
fix: separate an actual path from url search part before verification

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -130,7 +130,7 @@ function fastifySession (fastify, options, next) {
     return function handleSession (request, reply, done) {
       request.session = {}
 
-      const url = request.raw.url
+      const url = request.raw.url.split('?')[0]
       if (verifyPath(url, cookieOpts.path || '/') === false) {
         done()
         return


### PR DESCRIPTION
I encountered a problem that cookie.path option didn't work if:
1. Path was longer then just "/".
2. Get request had a query parameters.
