### PR TITLE
fix: manually persisting the session should make `isModified` return false

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -11,7 +11,7 @@ const cookieSignerKey = Symbol('cookieSignerKey')
 const generateId = Symbol('generateId')
 const requestKey = Symbol('request')
 const cookieOptsKey = Symbol('cookieOpts')
-const originalHash = Symbol('originalHash')
+const persistedHash = Symbol('persistedHash')
 const hash = Symbol('hash')
 const sessionIdKey = Symbol('sessionId')
 const sessionStoreKey = Symbol('sessionStore')
@@ -51,7 +51,7 @@ module.exports = class Session {
       }
     }
 
-    this[originalHash] = this[hash]()
+    this[persistedHash] = this[hash]()
   }
 
   touch () {
@@ -170,7 +170,12 @@ module.exports = class Session {
   save (callback) {
     if (callback) {
       this[sessionStoreKey].set(this[sessionIdKey], this, error => {
-        callback(error)
+        if (error) {
+          callback(error)
+        } else {
+          this[persistedHash] = this[hash]()
+          callback()
+        }
       })
     } else {
       return new Promise((resolve, reject) => {
@@ -178,6 +183,7 @@ module.exports = class Session {
           if (error) {
             reject(error)
           } else {
+            this[persistedHash] = this[hash]()
             resolve()
           }
         })
@@ -211,6 +217,6 @@ module.exports = class Session {
   }
 
   isModified () {
-    return this[originalHash] !== this[hash]()
+    return this[persistedHash] !== this[hash]()
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Following up #80. We're seeing some data loss after updating the session in a distributed, and the suspect is `onSend` in this library storing old data, overwriting the update performed by either a different concurrent request, or a request handled by another pod.

Note that this is slightly different from what `express-session` does.

https://github.com/expressjs/session/blob/1010fadc2f071ddf2add94235d72224cf65159c6/index.js#L403-L407

It tracks `modified` and `saved` separately. I'm not sure if that is necessary?