### PR TITLE
fix: remove cookie.expires from shouldSaveSession evaluation logic

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -235,7 +235,7 @@ function fastifySession (fastify, options, next) {
   function shouldSaveSession (request, cookieId, saveUninitializedSession, rollingSessions) {
     return cookieId !== request.session.encryptedSessionId
       ? saveUninitializedSession || request.session.isModified()
-      : rollingSessions || (Boolean(request.session.cookie.expires) && request.session.isModified())
+      : rollingSessions || request.session.isModified()
   }
 
   function option (options, key, def) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

In this PR, I have fixed an issue where the session is not saved when request.session.cookie.expires is null.

Previously, `rollingSessions || (Boolean(request.cookie.expires) && request.session.isModified())` was evaluated when `cookieId === request.session.encryptedSessionId`, that is, when the session already exists.

However, it seems that cookie.expires is not related to saving the session. Therefore, I have removed the process that evaluates cookie.expires.

This process was implemented in #149, but before that, cookie.expires was not evaluated.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
