### PR TITLE
perf: use `node:` prefix to bypass require.cache call for builtins

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -4,7 +4,7 @@ const redisStoreFactory = require('connect-redis')
 const Fastify = require('fastify')
 const Redis = require('ioredis')
 const fileStoreFactory = require('session-file-store')
-const { isMainThread } = require('worker_threads')
+const { isMainThread } = require('node:worker_threads')
 
 const fastifySession = require('..')
 const fastifyCookie = require('@fastify/cookie')

--- a/lib/idGenerator.js
+++ b/lib/idGenerator.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const randomBytes = require('crypto').randomBytes
+const randomBytes = require('node:crypto').randomBytes
 
 const cacheSize = 24 << 7
 let pos = 0

--- a/lib/session.js
+++ b/lib/session.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 const Cookie = require('./cookie')
 const { configure: configureStringifier } = require('safe-stable-stringify')

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,7 +1,7 @@
 'use strict'
 
-const EventEmitter = require('events').EventEmitter
-const util = require('util')
+const EventEmitter = require('node:events').EventEmitter
+const util = require('node:util')
 
 function Store (storeMap = new Map()) {
   this.store = storeMap

--- a/test/fastifySession.checkOptions.test.js
+++ b/test/fastifySession.checkOptions.test.js
@@ -4,7 +4,7 @@ const test = require('tap').test
 const Fastify = require('fastify')
 const fastifyCookie = require('@fastify/cookie')
 const fastifySession = require('..')
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 
 test('fastifySession.checkOptions: register should fail if no secret is specified', async t => {
   t.plan(1)

--- a/test/memorystore.test.js
+++ b/test/memorystore.test.js
@@ -2,7 +2,7 @@
 
 const test = require('tap').test
 const { MemoryStore } = require('../lib/store')
-const { EventEmitter } = require('stream')
+const { EventEmitter } = require('node:stream')
 
 test('MemoryStore.constructor: created MemoryStore should be an EventEmitter', (t) => {
   t.plan(2)


### PR DESCRIPTION
See https://github.com/fastify/fastify-static/pull/407

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
