### PR TITLE
Partitioned Cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The options object is used to generate the `Set-Cookie` header of the session co
 * `expires` - The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `maxAge` is used.
 * `sameSite`- The `boolean` or `string` of the `SameSite` attribute. Using `Secure` mode with `auto` attribute will change the behavior of the `SameSite` attribute in `http` mode. The `SameSite` attribute will automatically be set to `Lax` with an `http` request. See this [link](https://www.chromium.org/updates/same-site).
 * `domain` - The `Domain` attribute.
-
+* `partitioned`- The `boolean` value of the `Partitioned` attribute. Using the Partitioned attribute as part of Cookies Having Independent Partitioned State (CHIPS) to allow cross-site access with a separate cookie used per site.Defaults to false.
 ##### store
 A session store. Needs the following methods:
 * set(sessionId, session, callback)

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -10,8 +10,9 @@ module.exports = class Cookie {
     this.sameSite = cookie.sameSite || null
     this.domain = cookie.domain || null
     this.httpOnly = cookie.httpOnly !== undefined ? cookie.httpOnly : true
+    this.partitioned = cookie.partitioned ?? null
     this._expires = null
-
+    
     if (originalMaxAge) {
       this.maxAge = originalMaxAge
     } else if (cookie.expires) {
@@ -61,7 +62,8 @@ module.exports = class Cookie {
       secure: this.secure,
       path: this.path,
       httpOnly: this.httpOnly,
-      domain: this.domain
+      domain: this.domain,
+      partitioned: this.partitioned
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/session",
-  "version": "10.6.0",
+  "version": "10.7.0",
   "description": "a session plugin for fastify",
   "main": "lib/fastifySession.js",
   "type": "commonjs",

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -142,7 +142,7 @@ declare namespace fastifySession {
      *
      * @link https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
      */
-    cookie?: SerializeOptions;
+    cookie?: CookieOptions;
 
     /**
      * A session store.
@@ -172,6 +172,10 @@ declare namespace fastifySession {
      * Defaults to ""
      */
     cookiePrefix?: string;
+  }
+
+  export interface CookieOptions extends Omit<SerializeOptions, 'secure'> {
+    secure?: boolean | 'auto';
   }
 
   export class MemoryStore implements fastifySession.SessionStore {


### PR DESCRIPTION
Related to https://github.com/fastify/session/issues/213

- [x] run `npm run test` and `npm run benchmark`
npm run benchmark -> failed
TypeError: redisStoreFactory is not a function
    at createServer (C:\GitHub\fastify-session\benchmark\bench.js:19:24)
    at testFunction (C:\GitHub\fastify-session\benchmark\bench.js:56:18)
    at main (C:\GitHub\fastify-session\benchmark\bench.js:83:15)

- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
