### PR TITLE
Fix: add ability to create Partitioned Cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The options object is used to generate the `Set-Cookie` header of the session co
 * `expires` - The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `maxAge` is used.
 * `sameSite`- The `boolean` or `string` of the `SameSite` attribute. Using `Secure` mode with `auto` attribute will change the behavior of the `SameSite` attribute in `http` mode. The `SameSite` attribute will automatically be set to `Lax` with an `http` request. See this [link](https://www.chromium.org/updates/same-site).
 * `domain` - The `Domain` attribute.
-* `partitioned`- The `boolean` value of the `Partitioned` attribute. Using the Partitioned attribute as part of Cookies Having Independent Partitioned State (CHIPS) to allow cross-site access with a separate cookie used per site.Defaults to false.
+* `partitioned` (**experimental**) - The `boolean` value of the `Partitioned` attribute. Using the Partitioned attribute as part of Cookies Having Independent Partitioned State (CHIPS) to allow cross-site access with a separate cookie used per site. Defaults to false.
 
 ##### store
 A session store. Needs the following methods:

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ The options object is used to generate the `Set-Cookie` header of the session co
 * `expires` - The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `maxAge` is used.
 * `sameSite`- The `boolean` or `string` of the `SameSite` attribute. Using `Secure` mode with `auto` attribute will change the behavior of the `SameSite` attribute in `http` mode. The `SameSite` attribute will automatically be set to `Lax` with an `http` request. See this [link](https://www.chromium.org/updates/same-site).
 * `domain` - The `Domain` attribute.
+* `partitioned`- The `boolean` value of the `Partitioned` attribute. Using the Partitioned attribute as part of Cookies Having Independent Partitioned State (CHIPS) to allow cross-site access with a separate cookie used per site.Defaults to false.
 
 ##### store
 A session store. Needs the following methods:

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -10,7 +10,7 @@ module.exports = class Cookie {
     this.sameSite = cookie.sameSite || null
     this.domain = cookie.domain || null
     this.httpOnly = cookie.httpOnly !== undefined ? cookie.httpOnly : true
-    this.partitioned = cookie.partitioned ?? null
+    this.partitioned = cookie.partitioned ?? undefined
     this._expires = null
 
     if (originalMaxAge) {

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -10,7 +10,7 @@ module.exports = class Cookie {
     this.sameSite = cookie.sameSite || null
     this.domain = cookie.domain || null
     this.httpOnly = cookie.httpOnly !== undefined ? cookie.httpOnly : true
-    this.partitioned = cookie.partitioned ?? undefined
+    this.partitioned = cookie.partitioned
     this._expires = null
 
     if (originalMaxAge) {

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -10,6 +10,7 @@ module.exports = class Cookie {
     this.sameSite = cookie.sameSite || null
     this.domain = cookie.domain || null
     this.httpOnly = cookie.httpOnly !== undefined ? cookie.httpOnly : true
+    this.partitioned = cookie.partitioned ?? null
     this._expires = null
 
     if (originalMaxAge) {
@@ -61,7 +62,8 @@ module.exports = class Cookie {
       secure: this.secure,
       path: this.path,
       httpOnly: this.httpOnly,
-      domain: this.domain
+      domain: this.domain,
+      partitioned: this.partitioned
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/session",
-  "version": "10.6.2",
+  "version": "10.6.1",
   "description": "a session plugin for fastify",
   "main": "lib/fastifySession.js",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fastify/session",
-  "version": "10.6.1",
+  "version": "10.6.2",
   "description": "a session plugin for fastify",
   "main": "lib/fastifySession.js",
   "type": "commonjs",

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -415,6 +415,32 @@ test('should set session secure cookie secureAuto x-forwarded-proto header', asy
   t.match(response.headers['set-cookie'], /sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure/)
 })
 
+test('should set session partitioned cookie secure http encrypted', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.addHook('onRequest', async (request, reply) => {
+    request.raw.socket.encrypted = true
+  })
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: 'true', partitioned: true }
+  })
+  fastify.get('/', (request, reply) => {
+    request.session.test = {}
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.teardown(() => { fastify.close() })
+
+  const response = await fastify.inject({
+    url: '/'
+  })
+
+  t.equal(response.statusCode, 200)
+  t.match(response.headers['set-cookie'], /sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure; Partitioned/)
+})
+
 test('should use maxAge instead of expires in session if both are set in options.cookie', async (t) => {
   t.plan(3)
   const expires = new Date(34214461000) // 1971-02-01T00:01:01.000Z
@@ -510,7 +536,7 @@ test('Cookie', t => {
   const cookie = new Cookie({})
 
   t.test('properties', t => {
-    t.plan(9)
+    t.plan(10)
 
     t.equal('expires' in cookie, true)
     t.equal('originalMaxAge' in cookie, true)
@@ -521,10 +547,11 @@ test('Cookie', t => {
     t.equal('domain' in cookie, true)
     t.equal('_expires' in cookie, true)
     t.equal('maxAge' in cookie, true)
+    t.equal('partitioned' in cookie, true)
   })
 
   t.test('toJSON', t => {
-    t.plan(9)
+    t.plan(10)
 
     const json = cookie.toJSON()
 
@@ -535,6 +562,7 @@ test('Cookie', t => {
     t.equal('path' in json, true)
     t.equal('httpOnly' in json, true)
     t.equal('domain' in json, true)
+    t.equal('partitioned' in cookie, true)
 
     t.equal('_expires' in json, false)
     t.equal('maxAge' in json, false)

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -562,7 +562,7 @@ test('Cookie', t => {
     t.equal('path' in json, true)
     t.equal('httpOnly' in json, true)
     t.equal('domain' in json, true)
-    t.equal('partitioned' in cookie, true)
+    t.equal('partitioned' in json, true)
 
     t.equal('_expires' in json, false)
     t.equal('maxAge' in json, false)


### PR DESCRIPTION
Related to https://github.com/fastify/session/issues/213

- [x] run `npm run test` and `npm run benchmark`
npm run benchmark -> failed
TypeError: redisStoreFactory is not a function
    at createServer (C:\GitHub\fastify-session\benchmark\bench.js:19:24)
    at testFunction (C:\GitHub\fastify-session\benchmark\bench.js:56:18)
    at main (C:\GitHub\fastify-session\benchmark\bench.js:83:15)

- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
