### PR TITLE
fix: use request.protocol to check for HTTPS

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -1,7 +1,5 @@
 'use strict'
 
-const isConnectionSecure = require('./isConnectionSecure')
-
 module.exports = class Cookie {
   constructor (cookie, request) {
     const originalMaxAge = cookie.originalMaxAge || cookie.maxAge || null
@@ -23,7 +21,7 @@ module.exports = class Cookie {
     }
 
     if (this.secure === 'auto') {
-      if (isConnectionSecure(request)) {
+      if (request.protocol === 'https') {
         this.secure = true
       } else {
         this.sameSite = 'Lax'

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -4,7 +4,6 @@ const fp = require('fastify-plugin')
 const idGenerator = require('./idGenerator')()
 const Store = require('./store')
 const Session = require('./session')
-const isConnectionSecure = require('./isConnectionSecure')
 
 function fastifySession (fastify, options, next) {
   const error = checkOptions(options)
@@ -166,7 +165,7 @@ function fastifySession (fastify, options, next) {
 
       const cookieSessionId = getCookieSessionId(request)
       const saveSession = shouldSaveSession(request, cookieSessionId, saveUninitializedSession, rollingSessions)
-      const isInsecureConnection = cookieOpts.secure === true && isConnectionSecure(request) === false
+      const isInsecureConnection = cookieOpts.secure === true && request.protocol !== 'https'
       const sessionIdWithPrefix = hasCookiePrefix ? `${cookiePrefix}${session.encryptedSessionId}` : session.encryptedSessionId
       if (!saveSession || isInsecureConnection) {
         // if a session cookie is set, but has a different ID, clear it

--- a/lib/isConnectionSecure.js
+++ b/lib/isConnectionSecure.js
@@ -1,8 +1,0 @@
-'use strict'
-
-module.exports = function isConnectionSecure (request) {
-  return (
-    request.raw.socket?.encrypted === true ||
-    request.headers['x-forwarded-proto'] === 'https'
-  )
-}

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -54,7 +54,7 @@ test('should not set session cookie is request is not secure', async (t) => {
 
 test('should not set session cookie is request is not secure and x-forwarded-proto != https', async (t) => {
   t.plan(2)
-  const fastify = Fastify()
+  const fastify = Fastify({ trustProxy: true })
   fastify.addHook('onRequest', async (request, reply) => {
     request.raw.socket.encrypted = false
   })
@@ -75,7 +75,7 @@ test('should not set session cookie is request is not secure and x-forwarded-pro
 
 test('should set session cookie is request is not secure and x-forwarded-proto = https', async (t) => {
   t.plan(2)
-  const fastify = Fastify()
+  const fastify = Fastify({ trustProxy: true })
   fastify.addHook('onRequest', async (request, reply) => {
     request.raw.socket.encrypted = false
   })
@@ -182,7 +182,7 @@ test('should set session cookie with sameSite', async (t) => {
 
 test('should set session another path in cookie', async (t) => {
   t.plan(2)
-  const fastify = Fastify()
+  const fastify = Fastify({ trustProxy: true })
 
   const options = {
     secret: DEFAULT_SECRET,

--- a/test/util.js
+++ b/test/util.js
@@ -13,7 +13,7 @@ const DEFAULT_COOKIE_VALUE = `sessionId=${DEFAULT_ENCRYPTED_SESSION_ID};`
 const DEFAULT_COOKIE = `${DEFAULT_COOKIE_VALUE}; Path=/; HttpOnly; Secure`
 
 async function buildFastify (handler, sessionOptions, plugin) {
-  const fastify = Fastify()
+  const fastify = Fastify({ trustProxy: true })
   await fastify.register(fastifyCookie)
   if (plugin) {
     await fastify.register(plugin)


### PR DESCRIPTION
The header shouldn't be read unless `trustProxy` is true.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)