### PR TITLE
enhance checkOptions to reject invalid signer objects

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -203,14 +203,16 @@ function fastifySession (fastify, options, next) {
   }
 
   function checkOptions (options) {
-    if (!options.secret) {
-      return new Error('the secret option is required!')
-    }
-    if (typeof options.secret === 'string' && options.secret.length < 32) {
-      return new Error('the secret must have length 32 or greater')
-    }
-    if (Array.isArray(options.secret) && options.secret.length === 0) {
-      return new Error('at least one secret is required')
+    if (typeof options.secret === 'string') {
+      if (options.secret.length < 32) {
+        return new Error('the secret must have length 32 or greater')
+      }
+    } else if (Array.isArray(options.secret)) {
+      if (options.secret.length === 0) {
+        return new Error('at least one secret is required')
+      }
+    } else if (!(options.secret && typeof options.secret.sign === 'function' && typeof options.secret.unsign === 'function')) {
+      return new Error('the secret option is required, and must be a String, Array of Strings, or a signer object with .sign and .unsign methods')
     }
   }
 

--- a/test/fastifySession.checkOptions.test.js
+++ b/test/fastifySession.checkOptions.test.js
@@ -14,7 +14,7 @@ test('fastifySession.checkOptions: register should fail if no secret is specifie
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
 
-  await t.rejects(fastify.ready(), new Error('the secret option is required!'))
+  await t.rejects(fastify.ready(), new Error('the secret option is required, and must be a String, Array of Strings, or a signer object with .sign and .unsign methods'))
 })
 
 test('fastifySession.checkOptions: register should succeed if secret with 32 characters is specified', async t => {
@@ -72,4 +72,40 @@ test('fastifySession.checkOptions: register should fail if no secret is present 
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, { secret: [] })
   await t.rejects(fastify.ready(), new Error('at least one secret is required'))
+})
+
+test('fastifySession.checkOptions: register should fail if a Buffer is passed', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, { secret: crypto.randomBytes(32) })
+  await t.rejects(fastify.ready(), new Error('the secret option is required, and must be a String, Array of Strings, or a signer object with .sign and .unsign methods'))
+})
+
+test('fastifySession.checkOptions: register should fail if a signer missing unsign is passed', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  const invalidSigner = {
+    sign: (x) => x,
+    unsign: true
+  }
+
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, { secret: invalidSigner })
+  await t.rejects(fastify.ready(), new Error('the secret option is required, and must be a String, Array of Strings, or a signer object with .sign and .unsign methods'))
+})
+
+test('fastifySession.checkOptions: register should fail if a signer missing sign is passed', async t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  const invalidSigner = {
+    unsign: (x) => true
+  }
+
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, { secret: invalidSigner })
+  await t.rejects(fastify.ready(), new Error('the secret option is required, and must be a String, Array of Strings, or a signer object with .sign and .unsign methods'))
 })


### PR DESCRIPTION
I passed a Buffer instead of a string as a secret, and this resulted in an error message that "cookieSigner.sign is not a function" an at request time, rather than at plugin registration.

Someone else had a similar issue in the past https://github.com/fastify/help/issues/852

This PR makes `checkOptions` more comprehensive (explicitly checking for `.sign` and `.unsign` methods on signer objects passed as options.secret), and adds associated tests, so that this error is caught sooner and with a helpful message :)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [n/a] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
