### PR TITLE
fix race condition in cookie.maxAge test

### DIFF
--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -568,19 +568,31 @@ test('Cookie', t => {
     t.equal('maxAge' in json, false)
   })
 
+  // the clock ticks while we're testing, so to prevent occasional test
+  // failures where these tests tick over 1ms, take the time difference into
+  // account:
+
   t.test('maxAge calculated from expires', t => {
     t.plan(2)
 
+    const startT = Date.now()
     const cookie = new Cookie({ expires: new Date(Date.now() + 1000) })
-    t.equal(cookie.maxAge <= 1000, true)
+    const maxAge = cookie.maxAge
+    const duration = Date.now() - startT
+
+    t.equal(maxAge <= 1000 && maxAge >= 1000 - duration, true)
     t.equal(cookie.originalMaxAge, null)
   })
 
   t.test('maxAge set by maxAge', t => {
     t.plan(2)
 
+    const startT = Date.now()
     const cookie = new Cookie({ maxAge: 1000 })
-    t.equal(cookie.maxAge, 1000)
+    const maxAge = cookie.maxAge
+    const duration = Date.now() - startT
+
+    t.equal(maxAge <= 1000 && maxAge >= 1000 - duration, true)
     t.equal(cookie.originalMaxAge, 1000)
   })
 })


### PR DESCRIPTION
Fixes the race condition that caused tests to fail for https://github.com/fastify/session/pull/241

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
