### PR TITLE
Ensure maxAge type has milliseconds as the unit

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -174,7 +174,10 @@ declare namespace fastifySession {
     cookiePrefix?: string;
   }
 
-  export interface CookieOptions extends Omit<CookieSerializeOptions, 'signed'> {}
+  export interface CookieOptions extends Omit<CookieSerializeOptions, 'signed' | 'maxAge'> {
+    /** A `number` in milliseconds that specifies the `Expires` attribute by adding the specified milliseconds to the current date. If both `expires` and `maxAge` are set, then `expires` is used. */
+    maxAge?: number;
+  }
 
   export class MemoryStore implements fastifySession.SessionStore {
     constructor(map?: Map<string, Fastify.Session>);

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -7,8 +7,8 @@ import fastify, {
   Session
 } from 'fastify';
 import Redis from 'ioredis';
-import { expectAssignable, expectError, expectType } from 'tsd';
-import { MemoryStore, SessionStore, default as fastifySession, default as plugin } from '..';
+import { expectAssignable, expectDocCommentIncludes, expectError, expectType } from 'tsd';
+import { CookieOptions, MemoryStore, SessionStore, default as fastifySession, default as plugin } from '..';
 
 class EmptyStore {
   set(_sessionId: string, _session: any, _callback: Function) {}
@@ -46,9 +46,14 @@ app.register(plugin, {
 app.register(plugin, {
   secret,
   cookie: {
+    maxAge: 1000,
     secure: 'auto'
   }
 });
+
+const cookieMaxAge: CookieOptions = {};
+expectDocCommentIncludes<"millisecond">(cookieMaxAge.maxAge);
+
 app.register(plugin, {
   secret,
   store: new EmptyStore()


### PR DESCRIPTION
- This PR is meant to replace #227
- This PR is a two step plan to fix the `maxAge` unit issue. See follow-up step in #244

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
  - [x] run `npm run test`
  - [ ] run `npm run benchmark` ⚠️ unable to run due to `TypeError: redisStoreFactory is not a function`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


