### PR TITLE
use sha256 instead of sha1 as default

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -215,7 +215,7 @@ module.exports = class Session {
     })
 
     return crypto
-      .createHash('sha1')
+      .createHash('sha256')
       .update(str, 'utf8')
       .digest('hex')
   }


### PR DESCRIPTION
#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
