### PR TITLE
fix: `npm run benchmark` isn't working

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const redisStoreFactory = require('connect-redis')
+const RedisStore = require('connect-redis').default
 const Fastify = require('fastify')
 const Redis = require('ioredis')
 const fileStoreFactory = require('session-file-store')
@@ -16,7 +16,6 @@ function createServer (sessionPlugin, cookiePlugin, storeType) {
   let store
 
   if (storeType === 'redis') {
-    const RedisStore = redisStoreFactory(sessionPlugin)
     if (!redisClient) {
       redisClient = new Redis()
     }


### PR DESCRIPTION
The current `npm run benchmark` isn't working.

As stated in [Release v7.0.0 · tj/connect-redis](https://github.com/tj/connect-redis/releases/tag/v7.0.0), there is a breaking change about importing the package.

This PR fixes that.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
