### PR TITLE
Fix type argument inference of `session.get(key)` and `session.set(key, value)`

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -88,10 +88,10 @@ declare namespace fastifySession {
     save(): Promise<void>;
 
     /** sets values in the session. */
-    set<K extends keyof Fastify.Session, V = Fastify.Session[K]>(key: K, value: V): void;
+    set<K extends keyof Fastify.Session>(key: K, value: Fastify.Session[K]): void;
 
     /** gets values from the session. */
-    get<K extends keyof Fastify.Session, V = Fastify.Session[K] | undefined>(key: K): V;
+    get<K extends keyof Fastify.Session>(key: K): Fastify.Session[K] | undefined;
 
     /** checks if session has been modified since it was generated or loaded from the store. */
     isModified(): boolean;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -113,7 +113,7 @@ app.route({
       expectType<{ id: number } | undefined>(session?.user);
     });
     expectType<void>(request.session.set('foo', 'bar'));
-    expectType<string>(request.session.get<'foo', string>('foo'));
+    expectType<string | undefined>(request.session.get('foo'));
     expectType<void>(request.session.touch());
     expectType<boolean>(request.session.isModified());
     expectType<void>(request.session.reload(() => {}));
@@ -144,12 +144,18 @@ const app2 = fastify()
 app2.register(fastifySession)
 
 app2.get('/', async function(request) {
+  let num: number | undefined, str: string | undefined;
+  expectError(num = request.session.get('foo'));
+  expectAssignable(str = request.session.get('foo'));
+  expectError(request.session.set('foo', 2));
+  expectAssignable(request.session.set('foo', 'bar'));
+
   expectType<undefined | { id: number }>(request.session.get('user'))
   expectAssignable(request.session.set('user', { id: 2 }))
 
   expectError(request.session.get('not exist'))
   expectError(request.session.set('not exist', 'abc'))
 
-  expectType<'bar'>(request.session.get<any, 'bar'>('not exist'))
-  expectAssignable(request.session.set<any, string>('not exist', 'abc'))
+  expectType<any>(request.session.get<any>('not exist'))
+  expectAssignable(request.session.set<any>('not exist', 'abc'))
 })


### PR DESCRIPTION
The current generic method `session.get(key)` accidentally allows the return value to be inferred into any type.

The `session.set(key, value)` also allows `value` of any type to be passed in.

![Image](https://github.com/fastify/session/assets/9212875/fb80fc09-1a3b-45bb-8c63-909b1598c81d)

**Note:** This fix removes the second generic param `V`, so it will break an undocumented usage for TypeScript users specifying both two generic type parameters. (This should be rare.)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
