### PR TITLE
Added the ability to configure cookie options within a route

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,19 @@ Allows to destroy the session in the store. If you do not pass a callback, a Pro
 
 Updates the `expires` property of the session's cookie.
 
+#### Session#options(opts)
+
+Updates default options for setCookie inside a route.
+
+```js
+fastify.post('/', (request, reply) => {
+  request.session.set('data', request.body)
+  // .options takes any parameter that you can pass to setCookie
+  request.session.options({ maxAge: 60 * 60 }); // 3600 seconds => maxAge is always passed in seconds
+  reply.send('hello world')
+})
+```
+
 #### Session#regenerate([ignoreFields, ]callback)
 
 Regenerates the session by generating a new `sessionId` and persist it to the store. If you do not pass a callback, a Promise will be returned.

--- a/lib/session.js
+++ b/lib/session.js
@@ -56,6 +56,13 @@ module.exports = class Session {
     this[persistedHash] = this[hash]()
   }
 
+  options (opts) {
+    if (Object.keys(opts).length) {
+      this[cookieOptsKey] = opts
+      Object.assign(this.cookie, this[cookieOptsKey])
+    }
+  }
+
   touch () {
     if (this.cookie.originalMaxAge) {
       this.cookie.expires = new Date(Date.now() + this.cookie.originalMaxAge)

--- a/lib/session.js
+++ b/lib/session.js
@@ -58,8 +58,8 @@ module.exports = class Session {
 
   options (opts) {
     if (Object.keys(opts).length) {
-      this[cookieOptsKey] = opts
-      Object.assign(this.cookie, this[cookieOptsKey])
+      Object.assign(this[cookieOptsKey], opts)
+      this.cookie = new Cookie(this[cookieOptsKey], this[requestKey])
     }
   }
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1156,6 +1156,71 @@ test('Override global options', t => {
 
   fastify.post('/', (request, reply) => {
     request.session.set('data', request.body)
+    request.session.options({ maxAge: 1000 * 60 * 60 })
+
+    reply.send('hello world')
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (request, reply) => {
+    const data = request.session.get('data')
+
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    const { expires, path } = response.cookies[0]
+    t.equal(expires.toUTCString(), new Date(Date.now() + 1000 * 60 * 60).toUTCString())
+    t.equal(path, '/')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: response.headers['set-cookie']
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.equal(response.statusCode, 200)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+      t.ok(response.headers['set-cookie'])
+      const { expires, path } = response.cookies[0]
+      t.equal(expires.toUTCString(), new Date(Date.now() + 1000 * 60 * 60).toUTCString())
+      t.equal(path, '/')
+    })
+  })
+})
+
+test('Override global options with regenerate', t => {
+  t.plan(11)
+
+  const fastify = Fastify()
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    ...DEFAULT_OPTIONS,
+    cookie: {
+      secure: false,
+      maxAge: 42,
+      path: '/'
+    }
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
     request.session.options({ maxAge: 1000 * 60 * 60 }) // maxAge updated to 1 hour
 
     reply.send('hello world')

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -1083,3 +1083,119 @@ test('should save session if existing, modified, rolling false, and cookie.expir
   })
   t.equal(response3.statusCode, 200)
 })
+
+test('Custom options', async t => {
+  t.plan(6)
+
+  const fastify = Fastify()
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    ...DEFAULT_OPTIONS,
+    cookie: {
+      secure: false,
+      path: '/'
+    }
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    request.session.options({ maxAge: 1000 * 60 * 60 })
+    reply.send('hello world')
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (request, reply) => {
+    const data = request.session.get('data')
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    const { expires } = response.cookies[0]
+    t.equal(expires.toUTCString(), new Date(Date.now() + 1000 * 60 * 60).toUTCString())
+
+    fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: response.headers['set-cookie']
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+    })
+  })
+})
+
+test('Override global options', t => {
+  t.plan(7)
+
+  const fastify = Fastify()
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    ...DEFAULT_OPTIONS,
+    cookie: {
+      secure: false,
+      maxAge: 42,
+      path: '/'
+    }
+  })
+
+  fastify.post('/', (request, reply) => {
+    request.session.set('data', request.body)
+    request.session.options({ maxAge: 1000 * 60 * 60 })
+
+    reply.send('hello world')
+  })
+
+  t.teardown(fastify.close.bind(fastify))
+
+  fastify.get('/', (request, reply) => {
+    const data = request.session.get('data')
+
+    if (!data) {
+      reply.code(404).send()
+      return
+    }
+    reply.send(data)
+  })
+
+  fastify.inject({
+    method: 'POST',
+    url: '/',
+    payload: {
+      some: 'data'
+    }
+  }, (error, response) => {
+    t.error(error)
+    t.equal(response.statusCode, 200)
+    t.ok(response.headers['set-cookie'])
+    const { expires, path } = response.cookies[0]
+    t.equal(expires.toUTCString(), new Date(Date.now() + 1000 * 60 * 60).toUTCString())
+    t.equal(path, '/')
+
+    fastify.inject({
+      method: 'GET',
+      url: '/',
+      headers: {
+        cookie: response.headers['set-cookie']
+      }
+    }, (error, response) => {
+      t.error(error)
+      t.same(JSON.parse(response.payload), { some: 'data' })
+    })
+  })
+})


### PR DESCRIPTION
This PR add the ability to configure cookie options within a route. Relates to https://github.com/fastify/session/issues/257

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
