### PR TITLE
use 'lax' instead of 'Lax' as default for cookie sameSite option when secure is set to 'auto'

### DIFF
--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -28,7 +28,7 @@ module.exports = class Cookie {
       if (request.protocol === 'https') {
         this.secure = true
       } else {
-        this.sameSite = 'Lax'
+        this.sameSite = 'lax'
         this.secure = false
       }
     }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "url": "git+https://github.com/fastify/session.git"
   },
   "devDependencies": {
-    "@fastify/cookie": "^10.0.0",
+    "@fastify/cookie": "^11.0.0",
     "@fastify/pre-commit": "^2.1.0",
     "@types/node": "^22.0.0",
     "c8": "^10.1.2",

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -834,7 +834,7 @@ test("clears cookie if not backed by a session, and there's nothing to save", as
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  t.assert.strictEqual(response.headers['set-cookie'], 'sessionId=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax')
+  t.assert.strictEqual(response.headers['set-cookie'], 'sessionId=; Max-Age=0; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax')
 })
 
 test("clearing cookie sets the domain if it's specified in the cookie options", async t => {
@@ -853,7 +853,7 @@ test("clearing cookie sets the domain if it's specified in the cookie options", 
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  t.assert.strictEqual(response.headers['set-cookie'], 'sessionId=; Domain=domain.test; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax')
+  t.assert.strictEqual(response.headers['set-cookie'], 'sessionId=; Max-Age=0; Domain=domain.test; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax')
 })
 
 test('does not clear cookie if no session cookie in request', async t => {


### PR DESCRIPTION
Change to support @fastify/cookie ^11.0.0

When setting the secure option to 'auto' the cookie option of 'Lax' is being set by default for non HTTPS traffic, which is causing the jshttp/cookie module to throw as it now only supports the [lowercase option of 'lax'](https://github.com/jshttp/cookie/blob/master/src/index.ts#L332).

Had to update the tests to check for maxAge 0 on expiry which @fastify/cookie is now also [having to set](https://github.com/fastify/fastify-cookie/blame/master/plugin.js#L44) due to changes in jshttp/cookie.
