### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "connect-mongo": "^5.1.0",
     "connect-redis": "^7.1.1",
     "cronometro": "^4.0.0",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "ioredis": "^5.3.2",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.