### PR TITLE
fix(types): add missing SessionObject#options() definition

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -75,6 +75,9 @@ declare namespace fastifySession {
     regenerate(): Promise<void>;
     regenerate(ignoreFields: string[]): Promise<void>;
 
+    /** Set the session cookie options for this request handler. */
+    options(opts: Partial<CookieOptions>): void
+
     /** Allows to destroy the session in the store. */
     destroy(callback: Callback): void;
     destroy(): Promise<void>;

--- a/types/types.test-d.ts
+++ b/types/types.test-d.ts
@@ -8,7 +8,9 @@ import fastify, {
 } from 'fastify'
 import Redis from 'ioredis'
 import { expectAssignable, expectNotAssignable, expectDocCommentIncludes, expectError, expectType } from 'tsd'
-import { CookieOptions, MemoryStore, SessionStore, default as fastifySession, default as plugin } from '..'
+import fastifySession, { CookieOptions, MemoryStore, SessionStore } from '..'
+
+const plugin = fastifySession
 
 class EmptyStore {
   set (_sessionId: string, _session: any, _callback: Function) {}
@@ -126,6 +128,20 @@ app.route({
     expectType<Promise<void>>(request.session.regenerate())
     expectType<Promise<void>>(request.session.regenerate(['foo']))
     expectType<Promise<void>>(request.session.save())
+    expectError(request.session.options({ keyNotInCookieOptions: true }))
+    expectError(request.session.options({ signed: true }))
+    expectType<void>(request.session.options({}))
+    expectType<void>(request.session.options({
+      domain: 'example.com',
+      expires: new Date(),
+      httpOnly: true,
+      maxAge: 1000,
+      partitioned: true,
+      path: '/',
+      sameSite: 'lax',
+      priority: 'low',
+      secure: 'auto'
+    }))
   }
 })
 


### PR DESCRIPTION
Use the `CookieOptions` interface since it's more local (& seems accurate.) Thanks to @CamParry for identifying that.

Note: eslint on latest complained about the imports in the type, so I had to split them up. (Specifically it emitted `import-x/no-named-default` when run against the imports as originally authored, then `import-x/no-duplicates` when I split up the imports.)

Fixes #279.

I had to split up the import in types/t

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
