### PR TITLE
fix(tests): populate Set in idGenerator tests (#266)

### DIFF
--- a/test/idGenerator.test.js
+++ b/test/idGenerator.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test')
 const idGenerator = require('../lib/idGenerator')
 
-const cacheSize = 1 << 7 + 1
+const cacheSize = (1 << 7) + 1
 
 if (Buffer.isEncoding('base64url')) {
   test('should have no collisions, base64url', async (t) => {
@@ -11,12 +11,13 @@ if (Buffer.isEncoding('base64url')) {
     t.plan(cacheSize)
     const ids = new Set()
 
-    for (let i = 0; i < (cacheSize); ++i) {
+    for (let i = 0; i < cacheSize; ++i) {
       const id = idGen()
       if (ids.has(id)) {
         t.assert.ifError('had a collision')
       }
       t.assert.strictEqual(id.length, 32)
+      ids.add(id)
     }
   })
 }
@@ -26,11 +27,12 @@ test('should have no collisions, base64', async (t) => {
   t.plan(cacheSize)
   const ids = new Set()
 
-  for (let i = 0; i < (cacheSize); ++i) {
+  for (let i = 0; i < cacheSize; ++i) {
     const id = idGen()
     if (ids.has(id)) {
       t.assert.ifError('had a collision')
     }
     t.assert.strictEqual(id.length, 32)
+    ids.add(id)
   }
 })

--- a/test/idGenerator.test.js
+++ b/test/idGenerator.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test')
 const idGenerator = require('../lib/idGenerator')
 
-const cacheSize = (1 << 7) + 1
+const cacheSize = 1 << 7 + 1
 
 if (Buffer.isEncoding('base64url')) {
   test('should have no collisions, base64url', async (t) => {


### PR DESCRIPTION
## What

Add calls to `ids.add(id)` inside the loop in both `idGenerator` tests so that the `Set` is actually populated and the test detects real collisions.

## Why

Without this line, the `Set` remains empty and `ids.has(id)` never returns `true`, making the test pass even if the generator produces duplicate IDs. With this change, we ensure the test only passes if there are truly no collisions.

Closes #266

---

#### Checklist

- [x] Run `npm run test` and `npm run benchmark`  
- [x] Tests and/or benchmarks are included _(already existed and were adjusted)_  
- [ ] Documentation is changed or added _(no docs affected)_  
- [x] Commit message and code follow the [Developer’s Certificate of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of Conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)  
