### PR TITLE
refactor: standardize entry points and project structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const idGenerator = require('./idGenerator')()
-const Store = require('./store')
-const Session = require('./session')
+const idGenerator = require('./lib/idGenerator')()
+const Store = require('./lib/store')
+const Session = require('./lib/session')
 
 function fastifySession (fastify, options, next) {
   const error = checkOptions(options)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@fastify/session",
   "version": "11.1.1",
   "description": "a session plugin for fastify",
-  "main": "lib/fastifySession.js",
+  "main": "index.js",
   "type": "commonjs",
   "scripts": {
     "test": "npm run test:unit && npm run test:typescript",

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test')
 const Fastify = require('fastify')
 const fastifyCookie = require('@fastify/cookie')
-const fastifySession = require('../lib/fastifySession')
+const fastifySession = require('..')
 const fastifyPlugin = require('fastify-plugin')
 const Cookie = require('../lib/cookie')
 const { DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SECRET, buildFastify, DEFAULT_SESSION_ID } = require('./util')

--- a/test/util.js
+++ b/test/util.js
@@ -2,7 +2,7 @@
 
 const Fastify = require('fastify')
 const fastifyCookie = require('@fastify/cookie')
-const fastifySession = require('../lib/fastifySession')
+const fastifySession = require('..')
 const TestStore = require('./TestStore')
 
 const DEFAULT_SECRET = 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk'


### PR DESCRIPTION
Proposal:

Renamed the main plugin file to `index.js` to provide a standard entry point for the package. This simplifies imports and follows the common pattern used in the Fastify ecosystem.

Changes:

- Rename `fastifySession.js` → `index.js`
- Updated `package.json` main field
- Updated tests

See PR reference:
- https://github.com/fastify/fastify-url-data/pull/188