### PR TITLE
fix: preserve session store when reloading with callback

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -165,8 +165,9 @@ module.exports = class Session {
   reload (callback) {
     if (callback) {
       this[sessionStoreKey].get(this[sessionIdKey], (error, session) => {
-        this[requestKey].session = new Session(this[requestKey],
+        this[requestKey].session = new Session(
           this[sessionStoreKey],
+          this[requestKey],
           this[generateId],
           this[cookieOptsKey],
           this[cookieSignerKey],

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -613,6 +613,32 @@ test('should reload the session', async (t) => {
   t.assert.strictEqual(response.statusCode, 200)
 })
 
+test('should save the reloaded session with callback', async (t) => {
+  t.plan(3)
+  const fastify = await buildFastify((request, reply) => {
+    request.session.someData = 'some-data'
+    request.session.save((err) => {
+      t.assert.ifError(err)
+
+      request.session.reload((err) => {
+        t.assert.ifError(err)
+
+        reply.send(200)
+      })
+    })
+  }, {
+    ...DEFAULT_OPTIONS,
+    cookie: { secure: false }
+  })
+  t.after(() => fastify.close())
+
+  const response = await fastify.inject({
+    url: '/'
+  })
+
+  t.assert.strictEqual(response.statusCode, 200)
+})
+
 test('should save the session', async (t) => {
   t.plan(6)
   const fastify = await buildFastify((request, reply) => {


### PR DESCRIPTION

**Issue Link:**  https://github.com/fastify/session/issues/341 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
