### PR TITLE
fix session secure cookie override

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,7 +166,7 @@ function fastifySession (fastify, options, next) {
 
       const cookieSessionId = getCookieSessionId(request)
       const saveSession = shouldSaveSession(request, cookieSessionId, saveUninitializedSession, rollingSessions)
-      const isInsecureConnection = cookieOpts.secure === true && request.protocol !== 'https'
+      const isInsecureConnection = session.cookie.secure === true && request.protocol !== 'https'
       const sessionIdWithPrefix = hasCookiePrefix ? `${cookiePrefix}${session.encryptedSessionId}` : session.encryptedSessionId
       if (!saveSession || isInsecureConnection) {
         // if a session cookie is set, but has a different ID, clear it

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -3,7 +3,7 @@
 const test = require('node:test')
 const Signer = require('@fastify/cookie').Signer
 const fastifyPlugin = require('fastify-plugin')
-const { DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SESSION_ID, DEFAULT_SECRET, DEFAULT_ENCRYPTED_SESSION_ID, buildFastify } = require('./util')
+const { DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SESSION_ID, DEFAULT_SECRET, DEFAULT_ENCRYPTED_SESSION_ID, SIGNED_COOKIE_VALUE_PATTERN, buildFastify } = require('./util')
 const TestStore = require('./TestStore')
 const { setTimeout: sleep } = require('timers/promises')
 
@@ -72,7 +72,7 @@ test('should set session cookie', async (t) => {
   })
 
   t.assert.strictEqual(response1.statusCode, 200)
-  const pattern1 = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern1 = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern1).test(response1.headers['set-cookie']), true)
 
   const response2 = await fastify.inject({
@@ -81,7 +81,7 @@ test('should set session cookie', async (t) => {
   })
 
   t.assert.strictEqual(response2.statusCode, 200)
-  const pattern2 = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern2 = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern2).test(response2.headers['set-cookie']), true)
 })
 
@@ -129,7 +129,8 @@ test('should support multiple secrets', async (t) => {
     }
   })
   t.assert.strictEqual(response1.statusCode, 200)
-  t.assert.ok(response1.headers['set-cookie'].includes(encodeURIComponent(sessionIdSignedWithNewSecret)))
+  const setCookieValue = response1.headers['set-cookie'].split(';', 1)[0].slice('sessionId='.length)
+  t.assert.strictEqual(decodeURIComponent(setCookieValue), sessionIdSignedWithNewSecret)
 
   const response2 = await fastify.inject({
     url: '/',
@@ -162,7 +163,7 @@ test('should set session cookie using the specified cookie name', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`anothername=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`anothername=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -184,7 +185,7 @@ test('should set session cookie using the default cookie name', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -219,7 +220,7 @@ test('should set express sessions using the specified cookiePrefix', async (t) =
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`connect.sid=s%3A[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`connect.sid=s(?::|%3A)${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -315,7 +316,7 @@ test('should set new session cookie if expired', async (t) => {
 
   t.assert.strictEqual(response.headers['set-cookie'].includes(DEFAULT_ENCRYPTED_SESSION_ID), false)
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -338,7 +339,7 @@ test('should return new session cookie if does not exist in store', async (t) =>
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(response.headers['set-cookie'].includes(DEFAULT_ENCRYPTED_SESSION_ID), false)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -387,7 +388,7 @@ test('should create new session if cookie contains invalid session', async (t) =
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(response.headers['set-cookie'].includes('badinvalidsignaturenoooo'), false)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -427,7 +428,7 @@ test('should handle algorithm sha256', async (t) => {
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(response.headers['set-cookie'].includes(DEFAULT_ENCRYPTED_SESSION_ID), false)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -449,7 +450,7 @@ test('should handle algorithm sha512', async (t) => {
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(response.headers['set-cookie'].includes(DEFAULT_ENCRYPTED_SESSION_ID), false)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,135}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -472,6 +473,6 @@ test('should handle custom signer', async (t) => {
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(response.headers['set-cookie'].includes(DEFAULT_ENCRYPTED_SESSION_ID), false)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,135}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(RegExp(pattern).test(response.headers['set-cookie']), true)
 })

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -6,7 +6,7 @@ const fastifyCookie = require('@fastify/cookie')
 const fastifySession = require('..')
 const fastifyPlugin = require('fastify-plugin')
 const Cookie = require('../lib/cookie')
-const { DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SECRET, buildFastify, DEFAULT_SESSION_ID } = require('./util')
+const { DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SECRET, SIGNED_COOKIE_VALUE_PATTERN, buildFastify, DEFAULT_SESSION_ID } = require('./util')
 
 test('should set session cookie', async (t) => {
   t.plan(2)
@@ -29,7 +29,7 @@ test('should set session cookie', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -136,7 +136,7 @@ test('should set session cookie with expires if maxAge', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; Expires=[\w, :]{29}; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; Expires=[\w, :]{29}; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -158,7 +158,7 @@ test('should set session cookie with maxAge', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Domain=localhost; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Domain=localhost; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -180,7 +180,7 @@ test('should set session cookie with sameSite', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure; SameSite=Strict`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure; SameSite=Strict`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -207,7 +207,7 @@ test('should set session another path in cookie', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[[\w-%]{43,57}; Path=\/a\/test\/path; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/a\/test\/path; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -231,7 +231,7 @@ test('should set session cookie with expires', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; Expires=Mon, 01 Feb 1971 00:01:01 GMT; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; Expires=Mon, 01 Feb 1971 00:01:01 GMT; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -253,7 +253,7 @@ test('should set session non HttpOnly cookie', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -274,7 +274,7 @@ test('should set session non secure cookie', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -338,7 +338,7 @@ test('should set session non secure cookie secureAuto', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -365,7 +365,7 @@ test('should set session cookie secureAuto', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; SameSite=Lax`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; SameSite=Lax`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -392,7 +392,7 @@ test('should set session cookie secureAuto change SameSite', async (t) => {
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; SameSite=Lax`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; SameSite=Lax`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -419,7 +419,7 @@ test('should set session cookie secureAuto keep SameSite when secured', async (t
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure; SameSite=None`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure; SameSite=None`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -446,7 +446,7 @@ test('should set session secure cookie secureAuto http encrypted', async (t) => 
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -468,7 +468,7 @@ test('should set session secure cookie secureAuto x-forwarded-proto header', asy
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -495,7 +495,7 @@ test('should set session partitioned cookie secure http encrypted', async (t) =>
   })
 
   t.assert.strictEqual(response.statusCode, 200)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure; Partitioned`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure; Partitioned`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
@@ -521,9 +521,9 @@ test('should use maxAge instead of expires in session if both are set in options
   t.assert.strictEqual(response.statusCode, 200)
   // Expires attribute should be determined by options.maxAge -> Date.now() + 1000 and should have the same year from response.body,
   // and not determined by options.expires and should not have the year of 1971
-  const pattern1 = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; Expires=\w+, \d+ \w+ 1971 \d{2}:\d{2}:\d{2} GMT; HttpOnly; Secure/`
+  const pattern1 = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; Expires=\w+, \d+ \w+ 1971 \d{2}:\d{2}:\d{2} GMT; HttpOnly; Secure/`
   t.assert.strictEqual(new RegExp(pattern1).exec(response.headers['set-cookie']), null)
-  const pattern2 = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; Expires=\w+, \d+ \w+ ${dateFromBody.getFullYear()} \d{2}:\d{2}:\d{2} GMT; HttpOnly; Secure`
+  const pattern2 = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; Expires=\w+, \d+ \w+ ${dateFromBody.getFullYear()} \d{2}:\d{2}:\d{2} GMT; HttpOnly; Secure`
   t.assert.strictEqual(new RegExp(pattern2).test(response.headers['set-cookie']), true)
 })
 
@@ -588,7 +588,7 @@ test('when cookie secure is set to false then store secure as false', async t =>
 
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(typeof response.headers['set-cookie'], 'string')
-  const pattern = String.raw`^sessionId=[\w-]{32}.[\w-%]{43,135}; Path=\/; HttpOnly$`
+  const pattern = String.raw`^sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly$`
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -278,6 +278,49 @@ test('should set session non secure cookie', async (t) => {
   t.assert.strictEqual(new RegExp(pattern).test(response.headers['set-cookie']), true)
 })
 
+test('should use session cookie secure override when saving non secure cookie', async (t) => {
+  t.plan(3)
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: true }
+  }
+  const fastify = await buildFastify((request, reply) => {
+    request.session.options({ secure: false })
+    request.session.test = {}
+    reply.send(200)
+  }, options)
+  t.after(() => { fastify.close() })
+
+  const response = await fastify.inject({
+    url: '/'
+  })
+
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(typeof response.headers['set-cookie'], 'string')
+  t.assert.strictEqual(response.headers['set-cookie'].includes('Secure'), false)
+})
+
+test('should use session cookie secure override when saving secure cookie', async (t) => {
+  t.plan(2)
+  const options = {
+    secret: DEFAULT_SECRET,
+    cookie: { secure: false }
+  }
+  const fastify = await buildFastify((request, reply) => {
+    request.session.options({ secure: true })
+    request.session.test = {}
+    reply.send(200)
+  }, options)
+  t.after(() => { fastify.close() })
+
+  const response = await fastify.inject({
+    url: '/'
+  })
+
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(response.headers['set-cookie'], undefined)
+})
+
 test('should set session non secure cookie secureAuto', async (t) => {
   t.plan(2)
   const options = {

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -2,7 +2,7 @@
 
 const test = require('node:test')
 const fastifyPlugin = require('fastify-plugin')
-const { buildFastify, DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SECRET, DEFAULT_SESSION_ID } = require('./util')
+const { buildFastify, DEFAULT_OPTIONS, DEFAULT_COOKIE, DEFAULT_SECRET, DEFAULT_SESSION_ID, SIGNED_COOKIE_VALUE_PATTERN } = require('./util')
 
 test('should decorate request with sessionStore', async (t) => {
   t.plan(2)
@@ -64,7 +64,7 @@ test('should create new session if ENOENT error on store.get', async (t) => {
   })
 
   t.assert.strictEqual(response.headers['set-cookie'].includes('AAzZgRQddT1TKLkT3OZcnPsDiLKgV1uM1XHy2bIyqIg'), false)
-  const pattern = String.raw`sessionId=[\w-]{32}.[\w-%]{43,57}; Path=\/; HttpOnly; Secure`
+  const pattern = String.raw`sessionId=${SIGNED_COOKIE_VALUE_PATTERN}; Path=\/; HttpOnly; Secure`
   t.assert.strictEqual(RegExp(pattern).test(response.headers['set-cookie']), true)
   t.assert.strictEqual(response.statusCode, 200)
   t.assert.strictEqual(response.cookies[0].name, 'sessionId')

--- a/test/util.js
+++ b/test/util.js
@@ -11,6 +11,7 @@ const DEFAULT_SESSION_ID = 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN'
 const DEFAULT_ENCRYPTED_SESSION_ID = `${DEFAULT_SESSION_ID}.B7fUDYXU9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE`
 const DEFAULT_COOKIE_VALUE = `sessionId=${DEFAULT_ENCRYPTED_SESSION_ID};`
 const DEFAULT_COOKIE = `${DEFAULT_COOKIE_VALUE}; Path=/; HttpOnly; Secure`
+const SIGNED_COOKIE_VALUE_PATTERN = String.raw`[\w-]{32}\.[^;]+`
 
 async function buildFastify (handler, sessionOptions, plugin) {
   const fastify = Fastify({ trustProxy: true })
@@ -32,5 +33,6 @@ module.exports = {
   DEFAULT_SESSION_ID,
   DEFAULT_ENCRYPTED_SESSION_ID,
   DEFAULT_COOKIE_VALUE,
-  DEFAULT_COOKIE
+  DEFAULT_COOKIE,
+  SIGNED_COOKIE_VALUE_PATTERN
 }


### PR DESCRIPTION

## Summary 
Fix secure cookie override handling so the insecure-connection guard uses the effective per-session cookie config instead of the global default.

## Details

`Session#options()` can override cookie options for the current session. 
Previously, `onSend` checked `options.cookie.secure`, while the emitted Set-Cookie used `session.cookie.toJSON()`. 

This caused mismatched behavior when secure was overridden per request.

This change makes the guard check `session.cookie.secure`, matching the actual cookie that will be saved/sent.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
