### PR TITLE
fix: use named import for connect-redis v8.x

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const RedisStore = require('connect-redis').default
+const { RedisStore } = require('connect-redis')
 const Fastify = require('fastify')
 const Redis = require('ioredis')
 const fileStoreFactory = require('session-file-store')

--- a/examples/redis.js
+++ b/examples/redis.js
@@ -4,7 +4,7 @@ const Fastify = require('fastify')
 const fastifySession = require('..')
 const fastifyCookie = require('@fastify/cookie')
 const Redis = require('ioredis')
-const RedisStore = require('connect-redis').default
+const { RedisStore } = require('connect-redis')
 
 const fastify = Fastify()
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@types/node": "^26.0.1",
     "c8": "^11.0.0",
     "connect-mongo": "^6.0.0",
-    "connect-redis": "^7.1.1",
+    "connect-redis": "^8.0.0",
     "cronometro": "^6.0.3",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -1,5 +1,5 @@
 import MongoStore from 'connect-mongo'
-import RedisStore from 'connect-redis'
+import { RedisStore } from 'connect-redis'
 import fastify, {
   type FastifyInstance,
   type FastifyReply,


### PR DESCRIPTION
Proposal:

- Bumps `connect-redis` to `^8.0.0` and updates the imports that broke because of it ( see v8.0.0 here: https://github.com/tj/connect-redis/releases/tag/v9.0.0)

Changes:

- Since v8 ( see v8.0.0 here: https://github.com/tj/connect-redis/releases/tag/v8.0.0), `connect-redis` no longer has a default export `RedisStore` is now a named export only. This broke:

  - `types/index.tst.ts` — type-check failure (`tstyche`, TS2351: "This expression is not constructable")
  - `examples/redis.js` and `benchmark/bench.js` — runtime error, since`require('connect-redis').default` resolves to `undefined`
