### PR TITLE
fix: clear session cookie with configured path

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function fastifySession (fastify, options, next) {
       if (!saveSession || isInsecureConnection) {
         // if a session cookie is set, but has a different ID, clear it
         if (cookieSessionId && cookieSessionId !== session.encryptedSessionId) {
-          reply.clearCookie(cookieName, { domain: cookieOpts.domain })
+          reply.clearCookie(cookieName, { domain: cookieOpts.domain, path: cookieOpts.path || '/' })
         }
 
         if (session.isSaved()) {

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -856,6 +856,29 @@ test("clearing cookie sets the domain if it's specified in the cookie options", 
   t.assert.strictEqual(response.headers['set-cookie'], 'sessionId=; Max-Age=0; Domain=domain.test; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax')
 })
 
+test("clearing cookie sets the path if it's specified in the cookie options", async t => {
+  t.plan(2)
+  const fastify = Fastify({ trustProxy: true })
+  await fastify.register(fastifyCookie)
+  await fastify.register(fastifySession, {
+    ...DEFAULT_OPTIONS,
+    cookie: { path: '/admin' }
+  })
+  fastify.get('/admin', (_request, reply) => {
+    reply.send(200)
+  })
+  await fastify.listen({ port: 0 })
+  t.after(() => fastify.close())
+
+  const response = await fastify.inject({
+    url: '/admin',
+    headers: { cookie: DEFAULT_COOKIE_VALUE }
+  })
+
+  t.assert.strictEqual(response.statusCode, 200)
+  t.assert.strictEqual(response.headers['set-cookie'], 'sessionId=; Max-Age=0; Path=/admin; Expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax')
+})
+
 test('does not clear cookie if no session cookie in request', async t => {
   t.plan(2)
   const fastify = await buildFastify((_request, reply) => {


### PR DESCRIPTION

## Description in short 

Issue Link: https://github.com/fastify/session/issues/345 


Fixes session cookie cleanup when a custom cookie path is configured. 

clearCookie now includes the configured path, ensuring the browser deletes the same cookie identity that was originally set.

## reference 

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
