### PR TITLE
chore: upgrade connect-redis v9.x

### DIFF
--- a/benchmark/bench.js
+++ b/benchmark/bench.js
@@ -2,7 +2,7 @@
 
 const { RedisStore } = require('connect-redis')
 const Fastify = require('fastify')
-const Redis = require('ioredis')
+const { createClient } = require('redis')
 const fileStoreFactory = require('session-file-store')
 const { isMainThread } = require('node:worker_threads')
 
@@ -10,6 +10,7 @@ const fastifySession = require('..')
 const fastifyCookie = require('@fastify/cookie')
 
 let redisClient
+let redisClientConnecting
 
 function createServer (sessionPlugin, cookiePlugin, storeType) {
   let requestCounter = 0
@@ -17,7 +18,8 @@ function createServer (sessionPlugin, cookiePlugin, storeType) {
 
   if (storeType === 'redis') {
     if (!redisClient) {
-      redisClient = new Redis()
+      redisClient = createClient()
+      redisClientConnecting = redisClient.connect()
     }
     store = new RedisStore({ client: redisClient })
   } else if (storeType === 'file') {
@@ -55,6 +57,11 @@ function testFunction (sessionPlugin, cookiePlugin, storeType) {
   const server = createServer(sessionPlugin, cookiePlugin, storeType)
 
   return async function () {
+    if (redisClientConnecting) {
+      await redisClientConnecting
+      redisClientConnecting = null
+    }
+
     const { headers } = await server.inject('/')
     const setCookieHeader = headers['set-cookie']
 

--- a/examples/redis.js
+++ b/examples/redis.js
@@ -3,15 +3,16 @@
 const Fastify = require('fastify')
 const fastifySession = require('..')
 const fastifyCookie = require('@fastify/cookie')
-const Redis = require('ioredis')
+const { createClient } = require('redis')
 const { RedisStore } = require('connect-redis')
 
 const fastify = Fastify()
 
+const redisClient = createClient()
+redisClient.connect().catch(console.error)
+
 const store = new RedisStore({
-  client: new Redis({
-    enableAutoPipelining: true
-  })
+  client: redisClient
 })
 
 fastify.register(fastifyCookie, {})
@@ -27,8 +28,6 @@ fastify.get('/', (request, reply) => {
 })
 
 const response = fastify.inject('/')
-response.then(v => console.log(`
-
-autocannon -p 10 -H "Cookie=${decodeURIComponent(v.headers['set-cookie'])}" http://127.0.0.1:3000`))
+response.then(v => console.log(`\n\nautocannon -p 10 -H "Cookie=${decodeURIComponent(v.headers['set-cookie'])}" http://127.0.0.1:3000`))
 
 fastify.listen({ port: 3000 })

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npm run test:unit && npm run test:typescript",
     "test:unit": "c8 --100 node --test",
     "test:typescript": "tstyche",
+    "redis": "docker run -p 6379:6379 --rm redis",
     "benchmark": "node benchmark/bench.js",
     "lint": "eslint",
     "lint:fix": "eslint --fix"
@@ -65,12 +66,12 @@
     "@types/node": "^26.0.1",
     "c8": "^11.0.0",
     "connect-mongo": "^6.0.0",
-    "connect-redis": "^8.0.0",
+    "connect-redis": "^9.0.0",
     "cronometro": "^6.0.3",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
-    "ioredis": "^5.3.2",
     "neostandard": "^0.13.0",
+    "redis": "^6.0.0",
     "session-file-store": "^1.5.0",
     "tstyche": "^7.0.0"
   },

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -6,9 +6,13 @@ import fastify, {
   type FastifyRequest,
   type Session
 } from 'fastify'
-import Redis from 'ioredis'
+import { createClient } from 'redis'
 import { expect } from 'tstyche'
-import fastifySession, { type CookieOptions, MemoryStore, type SessionStore } from '..'
+import fastifySession, {
+  type CookieOptions,
+  MemoryStore,
+  type SessionStore
+} from '..'
 
 const plugin = fastifySession
 
@@ -25,7 +29,7 @@ declare module 'fastify' {
     user?: {
       id: number;
     };
-    foo: string
+    foo: string;
   }
 }
 
@@ -62,7 +66,7 @@ app.register(plugin, {
 })
 app.register(plugin, {
   secret,
-  store: new RedisStore({ client: new Redis() })
+  store: new RedisStore({ client: createClient() })
 })
 app.register(plugin, {
   secret,
@@ -77,19 +81,29 @@ app.register(plugin, {
   idGenerator: () => Date.now() + ''
 })
 app.register(plugin, {
-  secret,
+  secret
 })
 app.register(plugin, {
   secret,
-  idGenerator: (request) => `${request === undefined ? 'null' : request.ip}-${Date.now()}`
+  idGenerator: (request) =>
+    `${request === undefined ? 'null' : request.ip}-${Date.now()}`
 })
 
 expect(app.register).type.not.toBeCallableWith(plugin)
 expect(app.register).type.not.toBeCallableWith(plugin, {})
 
 expect(app.decryptSession).type.not.toBeInstantiableWith<[string]>()
-app.decryptSession<{ hello: 'world' }>('sessionId', { hello: 'world' }, () => ({}))
-app.decryptSession<{ hello: 'world' }>('sessionId', { hello: 'world' }, { domain: '/' }, () => ({}))
+app.decryptSession<{ hello: 'world' }>(
+  'sessionId',
+  { hello: 'world' },
+  () => ({})
+)
+app.decryptSession<{ hello: 'world' }>(
+  'sessionId',
+  { hello: 'world' },
+  { domain: '/' },
+  () => ({})
+)
 app.decryptSession('sessionId', {}, () => ({}))
 app.decryptSession('sessionId', {}, { domain: '/' }, () => ({}))
 
@@ -136,21 +150,25 @@ app.route({
     expect(request.session.regenerate(['foo'])).type.toBe<Promise<void>>()
     expect(request.session.save()).type.toBe<Promise<void>>()
 
-    expect(request.session.options).type.not.toBeCallableWith({ keyNotInCookieOptions: true })
+    expect(request.session.options).type.not.toBeCallableWith({
+      keyNotInCookieOptions: true
+    })
     expect(request.session.options).type.not.toBeCallableWith({ signed: true })
 
     expect(request.session.options({})).type.toBe<void>()
-    expect(request.session.options({
-      domain: 'example.com',
-      expires: new Date(),
-      httpOnly: true,
-      maxAge: 1000,
-      partitioned: true,
-      path: '/',
-      sameSite: 'lax',
-      priority: 'low',
-      secure: 'auto'
-    })).type.toBe<void>()
+    expect(
+      request.session.options({
+        domain: 'example.com',
+        expires: new Date(),
+        httpOnly: true,
+        maxAge: 1000,
+        partitioned: true,
+        path: '/',
+        sameSite: 'lax',
+        priority: 'low',
+        secure: 'auto'
+      })
+    ).type.toBe<void>()
   }
 })
 
@@ -169,8 +187,12 @@ const app2 = fastify()
 app2.register(fastifySession, { secret: 'DizIzSecret' })
 
 app2.get('/', async function (request) {
-  expect(request.session.get('foo')).type.toBeAssignableTo<string | undefined>()
-  expect(request.session.get('foo')).type.not.toBeAssignableTo<number | undefined>()
+  expect(request.session.get('foo')).type.toBeAssignableTo<
+    string | undefined
+  >()
+  expect(request.session.get('foo')).type.not.toBeAssignableTo<
+    number | undefined
+  >()
 
   expect(request.session.set('foo', 'bar')).type.toBe<void>()
 
@@ -183,5 +205,7 @@ app2.get('/', async function (request) {
   expect(request.session.set).type.not.toBeCallableWith('not exist', 'abc')
 
   expect(request.session.get<any>('not exist')).type.toBe<any>()
-  expect(request.session.set<any>('not exist', 'abc')).type.toBeAssignableTo<any>()
+  expect(
+    request.session.set<any>('not exist', 'abc')
+  ).type.toBeAssignableTo<any>()
 })


### PR DESCRIPTION
Proposal:

close #346 

- Upgrade `connect-redis` from v8.x to v9.x ( https://github.com/tj/connect-redis/releases/tag/v9.0.0 )
- Add the `redis` dependency instead of `ioredis`, because the `v9.x` version of `connect-redis` no longer supports `ioredis` 


Note: 
- This PR should resolved this PR: https://github.com/fastify/session/pull/307
