### PR TITLE
fix: destroy the previous session on regenerate

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,14 +95,8 @@ function fastifySession (fastify, options, next) {
       const expiration = restoredSession.cookie.originalExpires || restoredSession.cookie.expires
 
       if (expiration && expiration.getTime() <= Date.now()) {
-        restoredSession.destroy(err => {
-          if (err) {
-            done(err)
-            return
-          }
-
-          restoredSession.regenerate(done)
-        })
+        // `regenerate` destroys the expired session before issuing a new one.
+        restoredSession.regenerate(done)
         return
       }
 

--- a/lib/session.js
+++ b/lib/session.js
@@ -111,22 +111,29 @@ module.exports = class Session {
       }
     }
 
-    if (callback) {
-      this[sessionStoreKey].set(session.sessionId, session, error => {
-        this[requestKey].session = session
+    const oldSessionId = this[sessionIdKey]
 
-        callback(error)
+    if (callback) {
+      this[sessionStoreKey].destroy(oldSessionId, destroyError => {
+        this[sessionStoreKey].set(session.sessionId, session, setError => {
+          this[requestKey].session = session
+
+          callback(destroyError || setError)
+        })
       })
     } else {
       return new Promise((resolve, reject) => {
-        this[sessionStoreKey].set(session.sessionId, session, error => {
-          this[requestKey].session = session
+        this[sessionStoreKey].destroy(oldSessionId, destroyError => {
+          this[sessionStoreKey].set(session.sessionId, session, setError => {
+            this[requestKey].session = session
 
-          if (error) {
-            reject(error)
-          } else {
-            resolve()
-          }
+            const error = destroyError || setError
+            if (error) {
+              reject(error)
+            } else {
+              resolve()
+            }
+          })
         })
       })
     }

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -761,6 +761,49 @@ test('regenerate supports rejecting promises', async t => {
   t.assert.strictEqual(response.statusCode, 200)
 })
 
+test('regenerate destroys the previous session in the store', async (t) => {
+  t.plan(6)
+  const { MemoryStore } = require('../lib/store')
+  const store = new MemoryStore()
+
+  let oldSessionId
+  let newSessionId
+
+  const fastify = await buildFastify((request, reply) => {
+    if (request.session.get('userId')) {
+      // Second request: a session already exists in the store, regenerate it.
+      oldSessionId = request.session.sessionId
+      request.session.regenerate(error => {
+        if (error) {
+          reply.status(500).send('Error ' + error)
+          return
+        }
+        newSessionId = request.session.sessionId
+        reply.send(200)
+      })
+    } else {
+      // First request: create and persist a session.
+      request.session.set('userId', 42)
+      reply.send(200)
+    }
+  }, { ...DEFAULT_OPTIONS, cookie: { secure: false }, store })
+  t.after(() => fastify.close())
+
+  const response1 = await fastify.inject({ url: '/' })
+  t.assert.strictEqual(response1.statusCode, 200)
+  t.assert.strictEqual(store.store.size, 1)
+
+  const response2 = await fastify.inject({
+    url: '/',
+    headers: { Cookie: response1.headers['set-cookie'] }
+  })
+  t.assert.strictEqual(response2.statusCode, 200)
+
+  t.assert.notStrictEqual(newSessionId, oldSessionId)
+  t.assert.strictEqual(store.store.has(oldSessionId), false)
+  t.assert.strictEqual(store.store.has(newSessionId), true)
+})
+
 test('reload supports promises', async t => {
   t.plan(2)
   const fastify = await buildFastify(async (request, reply) => {


### PR DESCRIPTION
`Session#regenerate` creates and stores a new session but never removes the previous one from the store, leaving a stale entry behind (issue #240). Because the old session id stays valid in the store, this can contribute to session fixation, as noted in the issue thread.

This destroys the old session id before storing the regenerated one, mirroring `express-session`'s `store.regenerate` behavior (destroy old, then issue new). Any `destroy` error is surfaced through the same callback/promise as before (`destroyError || setError`).

The expired-session branch in the `onRequest` hook already called `destroy` explicitly before `regenerate`; that is now redundant and has been removed, so an expired session results in a single `destroy` rather than two.

Added a test asserting that after `regenerate` the previous session id is no longer present in the store while the new one is. Full suite passes at 100% coverage.

Closes #240
